### PR TITLE
Align topic naming with GitHub

### DIFF
--- a/pkg_building.Rmd
+++ b/pkg_building.Rmd
@@ -23,7 +23,7 @@ We strongly recommend that package developers read Hadley Wickham's concise but 
 
 ### Creating metadata for your package
 
-We recommend you to use the [`codemetar` package](https://github.com/ropensci/codemetar) for creating and updating a JSON [CodeMeta](https://codemeta.github.io/) metadata file for your package via `codemetar::write_codemeta()`. It will automatically include all useful information, including [GitHub rep keywords](#grooming). CodeMeta uses [Schema.org terms](https://schema.org/) so as it gains popularity the JSON metadata of your package might be used by third-party services, maybe even search engines. 
+We recommend you to use the [`codemetar` package](https://github.com/ropensci/codemetar) for creating and updating a JSON [CodeMeta](https://codemeta.github.io/) metadata file for your package via `codemetar::write_codemeta()`. It will automatically include all useful information, including [GitHub topics](#grooming). CodeMeta uses [Schema.org terms](https://schema.org/) so as it gains popularity the JSON metadata of your package might be used by third-party services, maybe even search engines. 
 
 ## Function/variable naming & general syntax
 


### PR DESCRIPTION
See diff ;-)

Also, I was the https://help.github.com/articles/classifying-your-repository-with-topics/ link [maintenance_github_grooming.Rmd](in https://github.com/ropensci/dev_guide/blob/73f4230acb895c241922349eb7402f21d897af73/maintenance_github_grooming.Rmd#github-repo-topics) choosen, because of the succinct advice presented there? If not, I would suggest to update it to https://blog.github.com/2017-01-31-introducing-topics/, because it introduces the... ;-D Topic better.