### PR TITLE
 backticks around help files with hyphens 

### DIFF
--- a/_output.yml
+++ b/_output.yml
@@ -12,11 +12,11 @@ bookdown::gitbook:
       after: |
         <li><a href="https://github.com/rstudio/bookdown" target="blank">Published with bookdown</a></li>
     edit:
-      link: https://github.com/ropensci/dev_guide/edit/master/%s
+      link: https://github.com/ropensci/dev_guide/edit/dev/%s
       text: "Edit this chapter"
-#    history:
-#      link: https://github.com/ropensci/dev_guide/commits/master/%s
-#      text: "Chapter edit history"
+    history:
+      link: https://github.com/ropensci/dev_guide/commits/master/%s
+      text: "Chapter edit history"
   favicon: images/icon_short_color.png
 bookdown::pdf_book:
   includes:

--- a/maintenance_evolution.Rmd
+++ b/maintenance_evolution.Rmd
@@ -131,7 +131,7 @@ Make a man page for deprecated functions like:
 NULL
 ```
 
-This creates a man page that users can access like `?helloworld-deprecated` and they'll see in the documentation index. Add any functions to this page as needed, and take away as a function moves to defunct (see below).
+This creates a man page that users can access like ``?`helloworld-deprecated` `` and they'll see in the documentation index. Add any functions to this page as needed, and take away as a function moves to defunct (see below).
 
 * In the next version (`v0.3.0`) you can make the function defunct (that is, completely gone from the package, except for a man page with a note about it).
 
@@ -182,4 +182,4 @@ Make a man page for defunct functions like:
 NULL
 ```
 
-This creates a man page that users can access like `?helloworld-defunct` and they'll see in the documentation index. Add any functions to this page as needed. You'll likely want to keep this man page indefinitely.
+This creates a man page that users can access like ``?`helloworld-defunct` `` and they'll see in the documentation index. Add any functions to this page as needed. You'll likely want to keep this man page indefinitely.

--- a/maintenance_releases.Rmd
+++ b/maintenance_releases.Rmd
@@ -36,3 +36,4 @@ a description of the new feature, improvement, bug fix, or deprecated function/f
 to any related GitHub issue like `(#12)`. The `(#12)` will resolve on GitHub in Releases to a link to that issue in the repo.
 * After you have added a `git tag` and pushed up to GitHub, add the news items for that tagged version to the Release notes of a release in your GitHub repo with a title like `pkgname v0.1.0`. See [GitHub docs about creating a release](https://help.github.com/articles/creating-releases/).
 * New CRAN releases will be tweeted about automatically by [roknowtifier](https://twitter.com/roknowtifier) and written about [in our biweekly newsletter](https://ropensci.github.io/biweekly/) but see [next chapter about marketing](#marketing) about how to inform more potential users about the release.
+* For more guidance about the NEWS file we suggest reading the [tidyverse NEWS style guide](https://style.tidyverse.org/news.html).

--- a/onboarding_intro.Rmd
+++ b/onboarding_intro.Rmd
@@ -56,7 +56,7 @@ rOpenSci's onboarding process is run by:
 We are grateful to the following individuals who have offered up their time and expertise to review packages submitted to rOpenSci.
 
 ```{r reviewers, echo=FALSE, results='asis'}
-editors <- c("Noam Ross", "Scott Chamberlain", "Karthik Ram", "Maëlle Salmon")
+editors <- c("Noam Ross", "Scott Chamberlain", "Karthik Ram", "Maëlle Salmon", "Anna Krystalli", "Lincoln Mullen")
 reviewers <- airtabler::airtable(base = "appZIB8hgtvjoV99D", 
                                 table = "Reviewers")
 reviewers <- reviewers$Reviewers$select_all()

--- a/pkg_building.Rmd
+++ b/pkg_building.Rmd
@@ -125,7 +125,7 @@ can be found at *link*".
 
 * We recommend using the `@family` tag in the documentation of functions to allow their grouping in the documentation of the installed package and potentially in the package's website, see [this section of Hadley Wickham's book](http://r-pkgs.had.co.nz/man.html) and [this section of the present chapter](#function-grouping) for more details.
 
-* The package should contain top-level documentation for `?foobar`, (or `?foobar-package` if there is a naming conflict). Optionally, you can use	both `?foobar` and `?foobar-package` for the package level manual file, using `@aliases` roxygen tag. `usethis::use_package_doc()` adds the template for the top-level documentation.
+* The package should contain top-level documentation for `?foobar`, (or ``?`foobar-package` `` if there is a naming conflict). Optionally, you can use	both `?foobar` and ``?`foobar-package` `` for the package level manual file, using `@aliases` roxygen tag. `usethis::use_package_doc()` adds the template for the top-level documentation.
 
 * The package should contain at least one vignette providing a substantial coverage of package functions, illustrating realistic use cases and how functions are intended to interact. If the package is small, the vignette and the README can have the same content. 
 


### PR DESCRIPTION
Help files with a minus/hyphen in their name need to be enclosed in backticks when called via `?`. E.g. ``?`base-deprecated` `` works, `?base-deprecated` throws an error.