### PR TITLE
add guidance about installation in reviewer guide

### DIFF
--- a/softwarereview_reviewer.Rmd
+++ b/softwarereview_reviewer.Rmd
@@ -9,7 +9,9 @@ Please strive to complete your review within 3 weeks of accepting a review reque
 additional or alternate reviewers if a review is excessively late.
 ```
 
-## Preparing your review 
+## Preparing your review
+
+Note that when installing the package to review it, you should use the `dependencies = TRUE` argument of `devtools::install()` to make sure you have all dependencies available.
 
 ### General guidelines
 


### PR DESCRIPTION
cf #112 

@cboettig regarding your remark about new package developers, what should we add to the current guidance "* Use `Imports` instead of `Depends` for packages providing functions from other packages. Make sure to list packages used for testing (`testthat`), and documentation (`knitr`, `roxygen2`) in your `Suggests` section of package dependencies. If you use any package in the examples or tests of your package, make sure to list it in `Suggests`, if not already listed in `Imports`."?