### PR TITLE
Refine guidelines on adding new contribs to DESCRIPTION

### DIFF
--- a/appendix.Rmd
+++ b/appendix.Rmd
@@ -4,6 +4,8 @@
 
 ## 0.2.0
 
+* 2019-04-23, add a sentence about why being generous with attributions.
+
 * 2019-04-23, add link to Daniel Nüst's notes about migration from XML to xml2.
 
 * 2019-04-22, ask reviewer for consent to be added to DESCRIPTION in review template.

--- a/appendix.Rmd
+++ b/appendix.Rmd
@@ -4,7 +4,7 @@
 
 ## 0.2.0
 
-* 2019-04-23, add a sentence about why being generous with attributions.
+* 2019-04-23, add a sentence about why being generous with attributions and more info about ctb vs aut.
 
 * 2019-04-23, add link to Daniel Nüst's notes about migration from XML to xml2.
 

--- a/maintenance_collaboration.Rmd
+++ b/maintenance_collaboration.Rmd
@@ -46,7 +46,7 @@ One particular aspect of working with collaborators is reviewing pull requests. 
 
 ### Be generous with attributions {#attributions}
 
-If someone contributes to your repository consider adding them in DESCRIPTION, as contributor ("ctb") for small contributions, author ("aut") for bigger contributions. Also consider adding their name near the feature/bug fix line in [NEWS.md](#news) We recommend your being generous with such acknowledgements.
+If someone contributes to your repository consider adding them in DESCRIPTION, as contributor ("ctb") for small contributions, author ("aut") for bigger contributions. Also consider adding their name near the feature/bug fix line in [NEWS.md](#news) We recommend your being generous with such acknowledgements, because it is a nice thing to do and because it will make folks more likely to contribute again to your package or other repos of the organization.
 
 As a reminder from [our packaging guidelines](#building) if your package was reviewed and you feel that your reviewers have made a substantial contribution to the development of your package, you may list them in the `Authors@R` field with a Reviewer contributor type (`"rev"`), like so:
 

--- a/maintenance_collaboration.Rmd
+++ b/maintenance_collaboration.Rmd
@@ -46,7 +46,11 @@ One particular aspect of working with collaborators is reviewing pull requests. 
 
 ### Be generous with attributions {#attributions}
 
-If someone contributes to your repository consider adding them in DESCRIPTION, as contributor ("ctb") for small contributions, author ("aut") for bigger contributions. Also consider adding their name near the feature/bug fix line in [NEWS.md](#news) We recommend your being generous with such acknowledgements, because it is a nice thing to do and because it will make folks more likely to contribute again to your package or other repos of the organization.
+If someone contributes to your repository consider adding them in DESCRIPTION, as contributor ("ctb") for small contributions, author ("aut") for bigger contributions. Traditionally when citing a package in a scientific publication only "aut" authors are listed, not "ctb" contributors; and on `pkgdown` websites only "aut" names are listed on the homepage, all authors being listed on the authors/ page. 
+
+At a minimum consider adding the name of contributors near the feature/bug fix line in [NEWS.md](#news). 
+
+We recommend your being generous with such acknowledgements, because it is a nice thing to do and because it will make folks more likely to contribute again to your package or other repos of the organization.
 
 As a reminder from [our packaging guidelines](#building) if your package was reviewed and you feel that your reviewers have made a substantial contribution to the development of your package, you may list them in the `Authors@R` field with a Reviewer contributor type (`"rev"`), like so:
 


### PR DESCRIPTION
@sckott in #127 you made a few suggestions

> Add justification for why maintainers should be generous with authorship (one eg: bc it is nice and bc it will make ppl feel like contributing again)

cf diff, is it enough?

>  how do they decide on using ctb vs. aut

I added info about the difference between the two. The choice criterion, however, is still vague (bigger contributions vs smaller contributions) but I'd find it hard to write clearer guidance, the maintainer can at least now make a more informed decision? But do _you_ have ideas of elements to add to help make a decision?

> what else?

There was no answer and I don't have any further idea, do you?
