### PR TITLE
http -> https

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -8,7 +8,7 @@ bibliography: [book.bib]
 biblio-style: apalike
 link-citations: yes
 github-repo: ropenscilabs/dev_guide
-url: 'http\://ropensci.github.io/dev_guide/'
+url: 'https\://ropensci.github.io/dev_guide/'
 description: "Extended version of the rOpenSci packaging guide."
 cover-image: images/cover.png
 apple-touch-icon: "images/apple-touch-icon.png"


### PR DESCRIPTION
(Following up on https://github.com/rstudio/bookdown.org/pull/31) bookdown.org only supports https resources.

If you republish the book after merging, I'll be able to scrape the cover image for bookdown.org.