### PR TITLE
Update JOSS instrucctions

### DIFF
--- a/templates/approved.md
+++ b/templates/approved.md
@@ -13,7 +13,7 @@ To-dos:
 <IF JOSS>
 - [ ] Activate Zenodo watching the repo
 - [ ] Tag and create a release so as to create a Zenodo version and DOI
-- [ ] Submit to JOSS using the Zenodo DOI.  We will tag it for expedited review.
+- [ ] Submit to JOSS at <https://joss.theoj.org/papers/new>. When a JOSS "PRE REVIEW" issue is generated for your paper, add the comment: `This package has been reviewed by rOpenSci: https://LINK.TO/THE/REVIEW/ISSUE, @ropensci/editors`
 <IF JOSS/>
 
 Should you want to acknowledge your reviewers in your package DESCRIPTION, you can do so by making them `"rev"`-type contributors in the `Authors@R` field (with their consent).  More info on this [here](https://devguide.ropensci.org/building.html#authorship).

--- a/templates/approved.md
+++ b/templates/approved.md
@@ -13,7 +13,7 @@ To-dos:
 <IF JOSS>
 - [ ] Activate Zenodo watching the repo
 - [ ] Tag and create a release so as to create a Zenodo version and DOI
-- [ ] Submit to JOSS at <https://joss.theoj.org/papers/new>. When a JOSS "PRE REVIEW" issue is generated for your paper, add the comment: `This package has been reviewed by rOpenSci: https://LINK.TO/THE/REVIEW/ISSUE, @ropensci/editors`
+- [ ] Submit to JOSS at <https://joss.theoj.org/papers/new>, using the rOpenSci GitHub repo URL. When a JOSS "PRE REVIEW" issue is generated for your paper, add the comment: `This package has been reviewed by rOpenSci: https://LINK.TO/THE/REVIEW/ISSUE, @ropensci/editors`
 <IF JOSS/>
 
 Should you want to acknowledge your reviewers in your package DESCRIPTION, you can do so by making them `"rev"`-type contributors in the `Authors@R` field (with their consent).  More info on this [here](https://devguide.ropensci.org/building.html#authorship).


### PR DESCRIPTION
As pointed out in https://github.com/openjournals/joss-reviews/issues/1622, one doesn't use the Zenodo DOI to submit to JOSS, this is handled later.  Added some instructions to allow the author to expedite the review themselves. @arfon