### PR TITLE
cran gotcha: single quoting software names

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -2,6 +2,8 @@ on:
   push:
     branches:
       master
+  schedule:
+    - cron:  '0 12 * * *'
   
 name: Render-Book-from-master
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,47 @@
+on:
+  push:
+    branches:
+      master
+  
+name: Render-Book-from-master
+
+jobs:
+  bookdown:
+    name: Render-Book
+    runs-on: macOS-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-pandoc@v1
+      - uses: r-lib/actions/setup-tinytex@v1
+      - name: Install dependencies
+        run: Rscript -e 'install.packages("remotes")' -e 'remotes::install_deps(dependencies = TRUE)'
+      - name: Render book html
+        run: Rscript -e 'bookdown::render_book("index.Rmd", "bookdown::gitbook", params = list(AIRTABLE_API_KEY = ${{ secrets.AIRTABLE_API_KEY }}))'
+        env: # Set the secret as an input
+          AIRTABLE_API_KEY: ${{ secrets.AIRTABLE_API_KEY }}
+      - name: Render book PDF
+        run: Rscript -e 'bookdown::render_book("index.Rmd", new_session = FALSE, "bookdown::pdf_book", output_dir = "pdfbook", params = list(AIRTABLE_API_KEY = ${{ secrets.AIRTABLE_API_KEY }}))'
+        env: # Set the secret as an input
+          AIRTABLE_API_KEY: ${{ secrets.AIRTABLE_API_KEY }}
+      - name: Move files around
+        run: Rscript -e 'file.copy(from = "pdfbook/ropensci-dev-guide.pdf", to = "_book/ropensci-dev-guide.pdf")' -e 'purrr::walk(list.files("images", full.names = TRUE), file.copy, to = "_book/images")'
+  checkout-and-deploy:
+   runs-on: ubuntu-latest
+   needs: bookdown
+   steps:
+     - name: Checkout
+       uses: actions/checkout@master
+     - name: Download artifact
+       uses: actions/download-artifact@v1.0.0
+       with:
+         # Artifact name
+         name: _book # optional
+         # Destination path
+         path: _book # optional
+     - name: Deploy to GitHub Pages
+       uses: Cecilapp/GitHub-Pages-deploy@master
+       env:
+          EMAIL: ${{ secrets.EMAIL }}               # must be a verified email
+          GH_TOKEN: ${{ secrets.GITHUB_PAT }} # https://github.com/settings/tokens
+          BUILD_DIR: _book/   

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -42,8 +42,6 @@ jobs:
          # Destination path
          path: _book # optional
      - name: Deploy to GitHub Pages
-       uses: Cecilapp/GitHub-Pages-deploy@master
-       env:
-          EMAIL: ${{ secrets.EMAIL }}               # must be a verified email
-          GH_TOKEN: ${{ secrets.GITHUB_PAT }} # https://github.com/settings/tokens
-          BUILD_DIR: _book/   
+       uses: maxheld83/ghpages@v0.2.1
+       env: 
+         BUILD_DIR: '_book/'

--- a/pkg_building.Rmd
+++ b/pkg_building.Rmd
@@ -304,6 +304,7 @@ This is a collection of CRAN gotchas that are worth avoiding at the outset.
 * Do not put a period on the end of your title.
 * Avoid starting the description with the package name or "This package ...".
 * Make sure you include links to websites if you wrap a web API, scrape data from a site, etc. in the `Description` field of your `DESCRIPTION` file. URLs should be enclosed in angle brackets, e.g. `<https://www.r-project.org>`.
+* In both the `Title` and `Description` fields, the names of packages or other external software must be quoted using single quotes (e.g., *'Rcpp' Integration for the 'Armadillo' Templated Linear Algebra Library*). 
 * Avoid long running tests and examples.  Consider `testthat::skip_on_cran` in tests to skip things that take a long time but still test them locally and on Travis.
 * Include top-level files such as `paper.md`, `.travis.yml` in your `.Rbuildignore` file.
 

--- a/preamble.tex
+++ b/preamble.tex
@@ -13,6 +13,7 @@ filecolor=rolink,
 citecolor=rolink,
 allcolors=rolink
     }
+\renewcommand{\linethickness}{0.05em}
 \newenvironment{summaryblock}
     {\begin{mdframed}[linecolor=roblue,linewidth=2pt]}
     {\end{mdframed}}


### PR DESCRIPTION
Not sure whether this is enforced consistently but I recently had a package rejected for failing to do so.
