### PR TITLE
Approved reviewer template

### DIFF
--- a/appendix.Rmd
+++ b/appendix.Rmd
@@ -213,6 +213,17 @@ Editors may make use of the e-mail template below in recruiting reviewers.
 
 ```
 
+# Reviewer approval comment template {#approval2template}
+
+
+```markdown
+```{r, eval = !knitr::is_latex_output(), child="templates/reviewer-approval.md"}
+```
+```
+
+```{r, eval = knitr::is_latex_output(), child="templates/reviewer-approval.md"}
+
+```
 
 # NEWS template {#newstemplate}
 

--- a/appendix.Rmd
+++ b/appendix.Rmd
@@ -4,6 +4,8 @@
 
 ## dev
 
+* 2020-09-11, make reviewer approval a separate template (@bisaloo, #264)
+
 * 2020-09-11, update the CI guidance (@bisaloo, @mcguinlu, #269)
 
 * 2020-09-11, improve the redirect guidance (@jeroen, @mcguinlu, #269)

--- a/softwarereview_editor.Rmd
+++ b/softwarereview_editor.Rmd
@@ -91,7 +91,7 @@ Each submission should be reviewed by _two_ package reviewers. Although it is fi
     `4/review-in-awaiting-changes` to update the reminder bot.
 -   Update Airtable database: Add the link to the review comment to the `review_url` field and the number of review hours to the `review_hours` field of each review record. 
 - If the author stops responding, refer to [the policies](#package-submission) and/or ping the other editors in the Slack channel for discussion. Importantly, if a reviewer was assigned to a closed issue, contact them when closing the issue to explain the decision, thank them once again for their work, and make a note in our database to assign them to a submission with high chances of smooth software review next time (e.g. a package author who has already submitted packages to us).
--   Upon changes being made, change the review status tag to `5/awaiting-reviewer-response`.
+-   Upon changes being made, change the review status tag to `5/awaiting-reviewer-response`, and request that reviewers indicate approval with the [reviewer approval template]{#approval2template}.
     
 ### After review:
 

--- a/softwarereview_reviewer.Rmd
+++ b/softwarereview_reviewer.Rmd
@@ -90,3 +90,5 @@ We encourage you to ask questions and provide feedback on the review process on 
 ## Review follow-up {#followupreviewer}
 
 Authors should respond within 2 weeks with their changes to the package in response to your review.  At this stage, we ask that you respond as to whether the changes sufficiently address any issues raised in your review. We encourage ongoing discussion between package authors and reviewers, and you may ask editors to clarify issues in the review thread as well.
+
+You'll use the [approval template](#approval2template).

--- a/templates/review.md
+++ b/templates/review.md
@@ -36,10 +36,6 @@ The package includes all the following forms of documentation:
    and a reasonable range of inputs and conditions. All tests pass on the local machine.
 - [ ] **Packaging guidelines**: The package conforms to the rOpenSci packaging guidelines
 
-#### Final approval (post-review)
-
-- [ ] **The author has responded to my review and made changes to my satisfaction. I recommend approving this package.**
-
 Estimated hours spent reviewing:
 
 - [ ] Should the author(s) deem it appropriate, I agree to be acknowledged as a package reviewer ("rev" role) in the package DESCRIPTION file.

--- a/templates/reviewer-approval.md
+++ b/templates/reviewer-approval.md
@@ -1,0 +1,10 @@
+## Reviewer Response
+
+
+#### Final approval (post-review)
+
+- [ ] **The author has responded to my review and made changes to my satisfaction. I recommend approving this package.**
+
+<!--Please update the estimate below.-->
+
+Estimated hours spent reviewing:


### PR DESCRIPTION
Fix #264 cc @Bisaloo

Pros:
* The reviewer / editor don't need to scroll up to find the review.
* A new comment is created when the reviewer approves (I've sometimes not noticed the reviewer edited their review)
* Time will be updated after re-review.

Con:
* Information from one review ends up in two places.
