### PR TITLE
fix bullet list rendering

### DIFF
--- a/softwarereview_editor.Rmd
+++ b/softwarereview_editor.Rmd
@@ -62,7 +62,8 @@ As a (guest) editor, use
 * the Airtable database of reviewers and volunteers 
 * and the authors of [rOpenSci packages](https://ropensci.org/packages/). 
 
-When these sources of information are not enough, 
+When these sources of information are not enough,
+
 * ping other editors in Slack for ideas, 
 * look for users of the package or of the data source/upstream service the package connects to (via their opening issues in the repository, starring it, citing it in papers, talking about it on Twitter). 
 * You can also search for authors of related packages on [r-pkg.org](https://r-pkg.org/).


### PR DESCRIPTION
One of the lists in [section 8.2.1.1.2 (_Where to look for reviewers_)](https://devguide.ropensci.org/editorguide.html#where-to-look-for-reviewers) isn't rendering correctly. This PR adds an empty line before the bullet point list, which should get it displaying correctly.