### PR TITLE
explicitly state requirement for two reviewers

### DIFF
--- a/softwarereview_editor.Rmd
+++ b/softwarereview_editor.Rmd
@@ -27,7 +27,7 @@ If you're a guest editor, thanks for helping! Please contact the editor who invi
 -   If initial checks show major gaps, request changes before assigning reviewers. If the author mentions changes might take time, [apply the holding label](#policiesreviewprocess).
 -   If the package raises a new issue for rOpenSci policy, start a conversation in Slack or open a discussion on the [rOpenSci forum](https://discuss.ropensci.org/) to discuss it with other editors ([example of policy discussion](https://discuss.ropensci.org/t/overlap-policy-for-package-onboarding/368)).
     
-### Look for and assign reviewers:
+### Look for and assign two reviewers:
 
 #### Tasks
 


### PR DESCRIPTION
@maelle: One of our new editors, @tdhock, who's looking after ropensci/software-review#475, was confused at the absence of explicit statement about how many reviewers were required. This seems the easiest and clearest way to make that explicit.