### PR TITLE
CI chapter updates

### DIFF
--- a/pkg_ci.Rmd
+++ b/pkg_ci.Rmd
@@ -26,7 +26,7 @@ R packages should have CI for all operating systems (Linux, Mac OSX, Windows) wh
 
 * Anything with file system / path calls
 
-In case of any doubt regarding the applicability of these criteria to your package, it's better to add CI for all platforms, and most often not too much hassle.
+In case of any doubt regarding the applicability of these criteria to your package, it's better to add CI for all operating systems. Most CI services standards setups for R packages allow this with not much hassle.
 
 ## Which continuous integration service(s)? {#whichci}
 

--- a/pkg_ci.Rmd
+++ b/pkg_ci.Rmd
@@ -12,17 +12,7 @@ All rOpenSci packages must use one form of continuous integration. This ensures 
 
 Both test status and code coverage should be reported via badges in your package README.
 
-## How to use continuous integration?
-
-The `usethis` package offers a few functions for continuous integration setup, see [the documentation](https://usethis.r-lib.org/reference/index.html#continuous-integration).
-
-Details will be provided below for different services.
-
-## Which continuous integration service(s)? {#whichci}
-
-Different continuous integration services will support builds on different operating systems.
-
-R packages should have CI for all platforms when they contain:
+R packages should have CI for all operating systems (Linux, Mac OSX, Windows) when they contain:
 
 * Compiled code
 
@@ -38,10 +28,13 @@ R packages should have CI for all platforms when they contain:
 
 In case of any doubt regarding the applicability of these criteria to your package, it's better to add CI for all platforms, and most often not too much hassle.
 
-### GitHub Actions (Linux, Mac OSX, Windows)
+## Which continuous integration service(s)? {#whichci}
 
-[GitHub Actions](https://github.com/features/actions) is a new CI service for which there are [examples and actions for R packages](https://github.com/r-lib/actions/), as well as [usethis support](https://usethis.r-lib.org/reference/use_github_action.html).
-It is gaining popularity.
+There are a number of continuous integration services, including standalone services (CircleCI, AppVeyor), and others integrated into code hosting or related services (GitHub Actions, GitLab, AWS Code Pipeline). Different services support different operating system configurations.
+
+[GitHub Actions](https://github.com/features/actions) is a convenient option for many R developers who already use GitHub as it is integrated into the platform and supports all needed operating Systems.  There are [actions supported for the R ecosystem](https://github.com/r-lib/actions/), as well and first-class support in the [{usethis}](https://usethis.r-lib.org/reference/use_github_action.html) package.
+
+[usethis supports CI setup for other systems](https://usethis.r-lib.org/reference/ci.html), though these functions are soft-deprecated. rOpenSci also supports the [circle](https://docs.ropensci.org/circle/) package, which aids in setting up CircleCI pipelines, and the [tic](https://docs.ropensci.org/tic/) package for building more complicated CI pipelines.
 
 #### Testing using different versions of R
 


### PR DESCRIPTION
 - Soft reccommend GitHub Actions, pointing to other resources
 - Use "Operating Systems" rather than "platforms" as "platforms" can refer to different CI services.
 - Separate "which service" from "which operating system" because most services now handle different operating systems.