### PR TITLE
Tweak rOpenSci onboarding info

### DIFF
--- a/maintenance_collaboration.Rmd
+++ b/maintenance_collaboration.Rmd
@@ -127,9 +127,9 @@ Please do not list editors as contributors. Your participation in and contributi
 
 If you give someone write permissions to the repository, 
 
-* please contact one of [the editors](#associateditors) so that this new contributor might get **invited to rOpenSci's "ropensci" GitHub organization** (instead of being [outside collaborators](https://help.github.com/articles/repository-permission-levels-for-an-organization/#outside-collaborators))
+* please contact a [staff member](https://ropensci.org/about#team) so that this new contributor might get **invited to rOpenSci's "ropensci" GitHub organization** (instead of being [outside collaborators](https://help.github.com/articles/repository-permission-levels-for-an-organization/#outside-collaborators))
 
-* please contact rOpenSci community manager [Stefanie Butland](https://github.com/stefaniebutland) so that this new contributor might get get **invited to rOpenSci Slack workspace**.
+* please contact rOpenSci [community manager or another staff member](https://ropensci.org/about#team) so that this new contributor might get get **invited to rOpenSci Slack workspace**.
 
 ## Further resources
 

--- a/maintenance_collaboration.Rmd
+++ b/maintenance_collaboration.Rmd
@@ -127,9 +127,9 @@ Please do not list editors as contributors. Your participation in and contributi
 
 If you give someone write permissions to the repository, 
 
-* please contact a [staff member](https://ropensci.org/about#team) so that this new contributor might get **invited to rOpenSci's "ropensci" GitHub organization** (instead of being [outside collaborators](https://help.github.com/articles/repository-permission-levels-for-an-organization/#outside-collaborators))
+* please contact a [staff member](https://ropensci.org/about#team) so that this new contributor might get **invited to rOpenSci's "ropensci" GitHub organization** (instead of being [an outside collaborator](https://help.github.com/articles/repository-permission-levels-for-an-organization/#outside-collaborators))
 
-* please contact rOpenSci [community manager or another staff member](https://ropensci.org/about#team) so that this new contributor might get get **invited to rOpenSci Slack workspace**.
+* please contact rOpenSci's [community manager or another staff member](https://ropensci.org/about#team) so that this new contributor might get get **invited to rOpenSci Slack workspace**.
 
 ## Further resources
 


### PR DESCRIPTION
I'm unsure how to phrase the invite to the GitHub org part. Ideally we'd want folks to contact me (or Noam) given we have owner access to the org but I don't want to use names. A slack channel maybe? The info email address?