### PR TITLE
Make link visible in redirect instructions

### DIFF
--- a/appendix.Rmd
+++ b/appendix.Rmd
@@ -357,7 +357,7 @@ cat(lines[2:(length(lines) - 1)], sep = "\n\n")
 
 ## Non GitHub pages site (e.g. Netlify)
 
-Replace the content of the current website with
+Replace the content of the current website with a `404.html` page:
 
 ```html
 <html>

--- a/appendix.Rmd
+++ b/appendix.Rmd
@@ -362,7 +362,7 @@ Replace the content of the current website with
 ```html
 <html>
 <head>
-<meta http-equiv="refresh" content="0;URL=https://docs.ropensci.org/<pkgname>/" />  
+<meta http-equiv="refresh" content="0;URL=https://docs.ropensci.org/<pkgname>/">  
 <script language="javascript">
   window.location.href = "https://docs.ropensci.org/<pkgname>"
 </script>

--- a/appendix.Rmd
+++ b/appendix.Rmd
@@ -376,5 +376,5 @@ You can setup the redirect from your main user gh-pages repository:
 
  - create a new repository (if you don't have one yet): `https://github.com/<username>/<username>.github.io`
  - In this repository create a directory `<pkgname>` containing the file `index.html` that redirects to the new location (see previous subsection)
- - Test that https://<username>.github.io/<pkgname>/index.html now redirects
+ - Test that `https://<username>.github.io/<pkgname>/index.html` now redirects
  - Optional: you could even create a `404.html` file in your `<username>.github.io` repo to redirect arbitrary pages.


### PR DESCRIPTION
Link appeared as:

> Test that https://.github.io//index.html now redirects

Should now appear as:

> Test that `https://<username>.github.io/<pkgname>/index.html` now redirects

---

In addition: close `meta` tag with regular `>` not `/>`

I'm also wondering if the Javascript is necessary? [This redirect](https://github.com/inbo/inbo.github.io/blob/master/wateRinfo/index.html) seems to work fine: 

```html
<!DOCTYPE html>
<meta charset="utf-8">
<title>Redirecting https://inbo.github.io/wateRinfo/</title>
<meta http-equiv="refresh" content="0; URL=https://ropensci.github.io/wateRinfo/">
<link rel="canonical" href="https://ropensci.github.io/wateRinfo/">
```

Or even shorter:
```html
<html>
  <head>
    <meta http-equiv="refresh" content="0; URL=https://docs.ropensci.org/frictionless/">
    <link rel="canonical" href="https://docs.ropensci.org/frictionless/">
  </head>
</html>
```

This works for https://frictionlessdata.github.io/frictionless-r/ ([source file](https://github.com/frictionlessdata/frictionless-r/blob/gh-pages/index.html))