### PR TITLE
Add missing words in review.md template

### DIFF
--- a/templates/review.md
+++ b/templates/review.md
@@ -28,8 +28,8 @@ The package includes all the following forms of documentation:
 #### Functionality
 
 - [ ] **Installation:** Installation succeeds as documented.
-- [ ] **Functionality:** Any functional claims of the software been confirmed.
-- [ ] **Performance:** Any performance claims of the software been confirmed.
+- [ ] **Functionality:** Any functional claims of the software have been confirmed.
+- [ ] **Performance:** Any performance claims of the software have been confirmed.
 - [ ] **Automated tests:** Unit tests cover essential functions of the package and a reasonable range of inputs and conditions. All tests pass on the local machine.
 - [ ] **Packaging guidelines**: The package conforms to the rOpenSci packaging guidelines.
 


### PR DESCRIPTION
Guessing that there was an implied "have" before "been".