### PR TITLE
Revisión Maintenance changing maintainers.es.rmd es auto

### DIFF
--- a/maintenance_changing_maintainers.es.Rmd
+++ b/maintenance_changing_maintainers.es.Rmd
@@ -6,7 +6,7 @@ Este capítulo presenta nuestra guía para asumir el mantenimiento de un paquete
 
 ## ¿Quieres dejar de mantener tu paquete?
 
-Nuestro newsletter quincenal tiene una sección de pedidos de colaboración denominada *Pedidos de contribuciones*. En la misma se destacan paquetes que buscan nuevas personas para encargarse del mantenimiento de un paquete. Si quieres dejar de mantener tu paquete, contáctanos para incluir tu paquete. Hasta ahora hemos tenido mucho éxito, encontrando responsables para todos los paquetes que lo necesitaron. 
+Nuestro newsletter quincenal tiene una sección de pedidos de colaboración denominada *"Call for Contributors"* (*Pedidos de contribuciones*, en inglés). En la misma se destacan paquetes que buscan nuevas personas para encargarse del mantenimiento. Si quieres dejar de mantener tu paquete, contáctanos para que lo incluyamos en esta sección. Hasta ahora hemos tenido mucho éxito, encontrando responsables para todos los paquetes que lo necesitaron. 
 
 ## ¿Quieres encargarte del mantenimiento de un paquete?
 
@@ -15,9 +15,9 @@ Nuestro newsletter quincenal tiene una sección de pedidos de colaboración deno
 ## Asumir el mantenimiento de un paquete
 
 - Agrégate en el archivo DESCRIPTION, con rol `role = c("aut", "cre")` y cambia el rol de la persona anterior a `role = c("aut")`.
-- Asegúrate reemplazar el nombre anterior en cualquier otra parte del paquete por el tuyo, manteniendo la a la persona anterior como autora (por ejemplo, en el archivo de manual a nivel de paquete, CONTRIBUTING.md, CITATION, etc...)
+- Asegúrate reemplazar el nombre anterior en cualquier otra parte del paquete por el tuyo, manteniendo a la persona anterior como autora (por ejemplo, en el archivo de manual a nivel de paquete, CONTRIBUTING.md, CITATION, etc...)
 - La [Guía de Colaboración](#collaboration) tiene consejos sobre cómo añadir nuevos miembros al equipo de mantenimiento y colaboración.
-- Para paquetes que han sido archivados o quedado [huérfanos en CRAN](https://cran.r-project.org/src/contrib/Orphaned/README), no es necesario el consentimiento de quien lo mantenía anteriormente para hacerse responsable del mismo en CRAN. En estos casos, contáctanos para que podamos ofrecerte la ayuda que necesites.
+- Para paquetes que han sido archivados o han quedado [huérfanos en CRAN](https://cran.r-project.org/src/contrib/Orphaned/README), no es necesario el consentimiento de quien lo mantenía anteriormente para hacerse responsable del mismo en CRAN. En estos casos, contáctanos para que podamos ofrecerte la ayuda que necesites.
 - Si el paquete no ha sido archivado por CRAN y cambia quien lo mantiene, haz que la persona responsable anterior envíe un correo electrónico a CRAN y ponga por escrito quién se hará cargo del mantenimiento de ahí en adelante. Asegúrate de mencionar que se envío ese correo cuando envíes la próxima versión a CRAN. Si quien mantenía al paquete no es localizable o no envía ese correo electrónico, ponte en contacto con el personal de rOpenSci.
 - Si puedes contactarte con quien te está transfiriendo el paquete, puedes organizar una reunión para que te explique cómo funciona. 
 
@@ -30,7 +30,7 @@ Depende; esto es lo que hay que hacer en diferentes situaciones:
 - el slack de rOpenSci: es bueno para obtener ayuda sobre problemas específicos o generales, consulta el canal #package-maintenance;
 - [Foro de discusión de rOpenSci](https://discuss.ropensci.org/c/package-development/29): este foro es una buena opción, siéntete libre de hacer cualquier pregunta allí;
 - [Equipo de rOpenSci](https://ropensci.org/about/#team): no dudes en contactarte con cualquier integrante del equipo por correo electrónico o enviando *issues* a GitHub, nos encantará ayudarte;
-- por supuesto, también hay ayuda general de R si eso se ajusta a tus necesidades: Foro de la comunidad de RStudio, StackOverflow, Twitter #rstats, etc.
+- por supuesto, también hay ayuda general de R si eso se ajusta a tus necesidades: Foro de la comunidad de RStudio, StackOverflow, Twitter y Mastodon #rstats, etc.
 
 - ¿Cuánto puedes/debes cambiar en el paquete?
 
@@ -46,9 +46,9 @@ Al pensar en esto, hay varias cosas a considerar.
 
 Como organización, a rOpenSci le interesa asegurarse de que los paquetes de nuestra suite estén disponibles mientras sean útiles para la comunidad. Si un paquete se queda sin personas que lo mantengan, en la mayoría de los casos intentaremos conseguir nuevas personas que se encarguen del mismo. Para ello, las siguientes tareas son responsabilidad del personal de rOpenSci.
 
-- Ten en cuenta que que un repositorio no haya ninguna actividad (*commits*, *issues*, *pull requests*) en mucho tiempo puede significar simplemente que se trata de un paquete maduro con poca necesidad de cambios.
+- Ten en cuenta que el hecho que un repositorio no haya ninguna actividad (*commits*, *issues*, *pull requests*) en mucho tiempo puede significar simplemente que se trata de un paquete maduro con poca necesidad de cambios.
 - Si no hay respuestas a reportes de problemas o *pull requests* en muchos meses, ya sea por email, *issues* en GitHub o mensajes de Slack:
   - Ponte en contacto para averiguar cuál es la situación. Puede que la persona encargada diga que le gustaría dejar de mantener el paquete, en cuyo caso busca un reemplazo.
 - Si no recibes respuesta o no puedes establecer el contacto:
-  - Si esto ocurre, insistiremos con el intento de contacto durante un máximo de un mes. Sin embargo, si la actualización del paquete es urgente, podemos utilizar nuestro acceso de administrador para realizar los cambios en su nombre.
+  - Si esto ocurre, insistiremos con el intento de contacto durante un mes como máximo. Sin embargo, si la actualización del paquete es urgente, podemos utilizar nuestro acceso de administrador para realizar los cambios en su nombre.
 - Haz un llamado en la sección "Pedidos de contribuciones" del boletín rOpenSci para buscar reemplazo - abre un *issue* en el [repo del boletín](https://github.com/ropensci/monthly/).

--- a/maintenance_changing_maintainers.es.Rmd
+++ b/maintenance_changing_maintainers.es.Rmd
@@ -6,7 +6,7 @@ Este capítulo presenta nuestra guía para asumir el mantenimiento de un paquete
 
 ## ¿Quieres dejar de mantener tu paquete?
 
-Nuestro newsletter quincenal tiene una sección de pedidos de colaboración denominada *Pedidos de contribuciones*. En la misma se destacan paquetes que buscan nuevas personas para encargarse del mantenimiento. Si quieres dejar de mantener tu paquete, contáctanos para incluir tu paquete. Hasta ahora hemos tenido mucho éxito, encontrando responsables para todos los paquetes que lo necesitaron. 
+Nuestro newsletter quincenal tiene una sección de pedidos de colaboración denominada *Pedidos de contribuciones*. En la misma se destacan paquetes que buscan nuevas personas para encargarse del mantenimiento de un paquete. Si quieres dejar de mantener tu paquete, contáctanos para incluir tu paquete. Hasta ahora hemos tenido mucho éxito, encontrando responsables para todos los paquetes que lo necesitaron. 
 
 ## ¿Quieres encargarte del mantenimiento de un paquete?
 
@@ -15,21 +15,21 @@ Nuestro newsletter quincenal tiene una sección de pedidos de colaboración deno
 ## Asumir el mantenimiento de un paquete
 
 - Agrégate en el archivo DESCRIPTION, con rol `role = c("aut", "cre")` y cambia el rol de la persona anterior a `role = c("aut")`.
-- Asegúrate reemplazar el nombre anterior nombre en cualquier otra parte del paquete por el tuyo, manteniendo la a la persona anterior como autora (por ejemplo, en el archivo de manual a nivel de paquete, CONTRIBUTING.md, CITATION, etc...)
+- Asegúrate reemplazar el nombre anterior en cualquier otra parte del paquete por el tuyo, manteniendo la a la persona anterior como autora (por ejemplo, en el archivo de manual a nivel de paquete, CONTRIBUTING.md, CITATION, etc...)
 - La [Guía de Colaboración](#collaboration) tiene consejos sobre cómo añadir nuevos miembros al equipo de mantenimiento y colaboración.
-- Para paquetes que han sido archivados o quedado [huérfano en CRAN](https://cran.r-project.org/src/contrib/Orphaned/README), no es necesario el consentimiento de quien lo mantenía anteriormente para hacerse responsable del mismo en CRAN. En estos casos, contáctanos para que podamos ofrecerte la ayuda que necesites.
-- Si el paquete no ha sido archivado por CRAN y cambia quien lo mantiene, haz que la persona responsable anterior envíe un correo electrónico a CRAN y ponga por escrito quién es lo se hará cargo del mantenimiento de ahí en adelante. Asegúrate de mencionar que enviaste ese correo cuando envíes la primera versión nueva a CRAN. Si quien mantenía al paquete no es localizable o no envía ese correo electrónico, ponte en contacto con el personal de rOpenSci.
+- Para paquetes que han sido archivados o quedado [huérfanos en CRAN](https://cran.r-project.org/src/contrib/Orphaned/README), no es necesario el consentimiento de quien lo mantenía anteriormente para hacerse responsable del mismo en CRAN. En estos casos, contáctanos para que podamos ofrecerte la ayuda que necesites.
+- Si el paquete no ha sido archivado por CRAN y cambia quien lo mantiene, haz que la persona responsable anterior envíe un correo electrónico a CRAN y ponga por escrito quién se hará cargo del mantenimiento de ahí en adelante. Asegúrate de mencionar que se envío ese correo cuando envíes la próxima versión a CRAN. Si quien mantenía al paquete no es localizable o no envía ese correo electrónico, ponte en contacto con el personal de rOpenSci.
 - Si puedes contactarte con quien te está transfiriendo el paquete, puedes organizar una reunión para que te explique cómo funciona. 
 
 ### Preguntas frecuentes
 
-- Hay algunos issues no resueltos del paquete que no sé cómo arreglar. ¿A quién puedo pedir ayuda? 
+- Hay algunos *issues* no resueltos del paquete que no sé cómo arreglar. ¿A quién puedo pedir ayuda? 
 Depende; esto es lo que hay que hacer en diferentes situaciones:
 
 - si se puede contactar con la persona anterior, contáctate con ella y pídele ayuda.
-- el slack de rOpenSci: es bueno para obtener ayuda sobre problemas específicos o generales, consulta el canal #mantenimiento-de-paquetes;
+- el slack de rOpenSci: es bueno para obtener ayuda sobre problemas específicos o generales, consulta el canal #package-maintenance;
 - [Foro de discusión de rOpenSci](https://discuss.ropensci.org/c/package-development/29): este foro es una buena opción, siéntete libre de hacer cualquier pregunta allí;
-- [Equipo de rOpenSci](https://ropensci.org/about/#team): no dudes en contactarte con cualquier integrante del equipo por correo electrónico o enviando issues a GitHub, nos encantará ayudarte;
+- [Equipo de rOpenSci](https://ropensci.org/about/#team): no dudes en contactarte con cualquier integrante del equipo por correo electrónico o enviando *issues* a GitHub, nos encantará ayudarte;
 - por supuesto, también hay ayuda general de R si eso se ajusta a tus necesidades: Foro de la comunidad de RStudio, StackOverflow, Twitter #rstats, etc.
 
 - ¿Cuánto puedes/debes cambiar en el paquete?
@@ -46,9 +46,9 @@ Al pensar en esto, hay varias cosas a considerar.
 
 Como organización, a rOpenSci le interesa asegurarse de que los paquetes de nuestra suite estén disponibles mientras sean útiles para la comunidad. Si un paquete se queda sin personas que lo mantengan, en la mayoría de los casos intentaremos conseguir nuevas personas que se encarguen del mismo. Para ello, las siguientes tareas son responsabilidad del personal de rOpenSci.
 
-- Ten en cuenta que que un repositorio no haya visto ninguna actividad (commits, issues, pull requests) en mucho tiempo puede  significar simplemente que se trata de un paquete maduro con poca necesidad de cambios.
-- Si no hay respuestas a reportes de problemas o pull requests en muchos meses, ya sea por email, issues en GitHub o mensajes de Slack:
-  - Ponte en contacto para averiguar cuál es la situación. Puede que diga que le gustaría dejar de mantener el paquete, en cuyo caso busca un reemplazo.
+- Ten en cuenta que que un repositorio no haya ninguna actividad (*commits*, *issues*, *pull requests*) en mucho tiempo puede significar simplemente que se trata de un paquete maduro con poca necesidad de cambios.
+- Si no hay respuestas a reportes de problemas o *pull requests* en muchos meses, ya sea por email, *issues* en GitHub o mensajes de Slack:
+  - Ponte en contacto para averiguar cuál es la situación. Puede que la persona encargada diga que le gustaría dejar de mantener el paquete, en cuyo caso busca un reemplazo.
 - Si no recibes respuesta o no puedes establecer el contacto:
   - Si esto ocurre, insistiremos con el intento de contacto durante un máximo de un mes. Sin embargo, si la actualización del paquete es urgente, podemos utilizar nuestro acceso de administrador para realizar los cambios en su nombre.
-- Haz un llamado en la sección "Call for Contributors" del boletín rOpenSci para buscar reemplazo - abre un issue en el [repo del boletín](https://github.com/ropensci/monthly/).
+- Haz un llamado en la sección "Pedidos de contribuciones" del boletín rOpenSci para buscar reemplazo - abre un *issue* en el [repo del boletín](https://github.com/ropensci/monthly/).

--- a/maintenance_changing_maintainers.es.Rmd
+++ b/maintenance_changing_maintainers.es.Rmd
@@ -1,61 +1,54 @@
 # Cambio de mantenedores de paquetes {#changing-maintainers}
 
-```{block, type="summaryblock"}
+```{block, type='summaryblock'}
 Este capítulo presenta nuestra guía para asumir el mantenimiento de un paquete.
 ```
 
-## ¿Quieres dejar el mantenimiento de tu paquete?
+## ¿Quieres dejar de mantener tu paquete?
 
-Tenemos una sección de petición de colaboradores en nuestro boletín que sale cada dos semanas. La sección se llama *Llamada a colaboradores*. En esa sección destacamos los paquetes que buscan nuevos mantenedores. Si quieres dejar el papel de mantenedor de tu paquete, ponte en contacto con nosotros y podremos destacar tu paquete en nuestro boletín. Hasta ahora hemos tenido mucho éxito, encontrando nuevos mantenedores para seis de los seis paquetes.
+Nuestro newsletter quincenal tiene una sección de pedidos de colaboración denominada *Pedidos de contribuciones*. En la misma se destacan paquetes que buscan nuevas personas para encargarse del mantenimiento. Si quieres dejar de mantener tu paquete, contáctanos para incluir tu paquete. Hasta ahora hemos tenido mucho éxito, encontrando responsables para todos los paquetes que lo necesitaron. 
 
 ## ¿Quieres encargarte del mantenimiento de un paquete?
 
-Tenemos una sección de solicitud de colaboradores en nuestro boletín que sale cada dos semanas. La sección se llama *Llamada a colaboradores*. En esa sección destacamos los paquetes que buscan nuevos mantenedores. Si aún no estás suscrito al boletín, es una buena idea [suscribirte a](https://news.ropensci.org/) para recibir una notificación cuando haya un paquete que busque un nuevo mantenedor.
+Nuestro newsletter quincenal tiene una sección de pedidos de colaboración denominada *Pedidos de contribuciones*. En la misma se destacan paquetes que buscan nuevas personas para encargarse del mantenimiento. Si aún lo hiciste, es una buena idea [subscribirte al newsletter](https://news.ropensci.org/) para recibir notificaciones cuando hay un paquete buscando ayuda. 
 
 ## Asumir el mantenimiento de un paquete
 
-- Añádase como nuevo mantenedor en el archivo DESCRIPTION, con `role = c("aut", "cre")`y haz que el antiguo mantenedor `aut` sólo.
-- Asegúrate de cambiar el mantenedor por tu nombre en cualquier otra parte del paquete, manteniendo al antiguo mantenedor como autor (por ejemplo, en el archivo de manual a nivel de paquete, CONTRIBUTING.md, CITATION, etc.)
-- El sitio web [Guía de Colaboración](#collaboration) tiene orientaciones sobre cómo añadir nuevos mantenedores y colaboradores
-- Los paquetes que han sido archivados o \[huérfanos\]\[\] en CRAN no necesitan el permiso del anterior mantenedor para ser retomados en CRAN. En estos casos, ponte en contacto con nosotros para que podamos ofrecerte la ayuda que necesites.
-- Si el paquete no ha sido archivado por CRAN y hay un cambio de mantenedor, haz que el antiguo mantenedor envíe un correo electrónico a CRAN y ponga por escrito quién es el nuevo mantenedor. Asegúrate de mencionar ese correo electrónico sobre el cambio de mantenedor cuando envíes la primera versión nueva a CRAN. Si el antiguo mantenedor no está localizable o no envía este correo electrónico, ponte en contacto con el personal de rOpenSci.
-- Si el antiguo mantenedor está localizable, programar una reunión te ayudará a conseguir la "disposición del terreno".
+- Agrégate en el archivo DESCRIPTION, con rol `role = c("aut", "cre")` y cambia el rol de la persona anterior a `role = c("aut")`.
+- Asegúrate reemplazar el nombre anterior nombre en cualquier otra parte del paquete por el tuyo, manteniendo la a la persona anterior como autora (por ejemplo, en el archivo de manual a nivel de paquete, CONTRIBUTING.md, CITATION, etc...)
+- La [Guía de Colaboración](#collaboration) tiene consejos sobre cómo añadir nuevos miembros al equipo de mantenimiento y colaboración.
+- Para paquetes que han sido archivados o quedado [huérfano en CRAN](https://cran.r-project.org/src/contrib/Orphaned/README), no es necesario el consentimiento de quien lo mantenía anteriormente para hacerse responsable del mismo en CRAN. En estos casos, contáctanos para que podamos ofrecerte la ayuda que necesites.
+- Si el paquete no ha sido archivado por CRAN y cambia quien lo mantiene, haz que la persona responsable anterior envíe un correo electrónico a CRAN y ponga por escrito quién es lo se hará cargo del mantenimiento de ahí en adelante. Asegúrate de mencionar que enviaste ese correo cuando envíes la primera versión nueva a CRAN. Si quien mantenía al paquete no es localizable o no envía ese correo electrónico, ponte en contacto con el personal de rOpenSci.
+- Si puedes contactarte con quien te está transfiriendo el paquete, puedes organizar una reunión para que te explique cómo funciona. 
 
-### Preguntas frecuentes para los nuevos mantenedores
+### Preguntas frecuentes
 
-- Hay algunos issues no resueltos del paquete que no sé cómo arreglar. ¿A quién puedo pedir ayuda?
-  
-  Depende; esto es lo que hay que hacer en diferentes situaciones:
+- Hay algunos issues no resueltos del paquete que no sé cómo arreglar. ¿A quién puedo pedir ayuda? 
+Depende; esto es lo que hay que hacer en diferentes situaciones:
 
-
-```
-- si se puede contactar con el antiguo mantenedor: ponte en contacto con él y pídele ayuda;
-- rOpenSci slack: es bueno para obtener ayuda sobre problemas específicos o generales, consulta el canal #mantenimiento-de-paquetes;
+- si se puede contactar con la persona anterior, contáctate con ella y pídele ayuda.
+- el slack de rOpenSci: es bueno para obtener ayuda sobre problemas específicos o generales, consulta el canal #mantenimiento-de-paquetes;
 - [Foro de discusión de rOpenSci](https://discuss.ropensci.org/c/package-development/29): este foro es una buena opción, siéntete libre de hacer cualquier pregunta allí;
-- [Personal de rOpenSci](https://ropensci.org/about/#team): no dudes en ponerte en contacto con uno de nosotros por correo electrónico/enviando issues a GitHub, estaremos encantados de ayudarte;
+- [Equipo de rOpenSci](https://ropensci.org/about/#team): no dudes en contactarte con cualquier integrante del equipo por correo electrónico o enviando issues a GitHub, nos encantará ayudarte;
 - por supuesto, también hay ayuda general de R si eso se ajusta a tus necesidades: Foro de la comunidad de RStudio, StackOverflow, Twitter #rstats, etc.
-```
 
 - ¿Cuánto puedes/debes cambiar en el paquete?
-  
-  Para obtener ayuda general sobre cómo cambiar el código de un paquete, consulta la sección [Evolución del paquete](#evolution)
-  sección.
-  
-  Al pensar en esto, hay muchas consideraciones.
-  
-  ¿Cuánto tiempo tienes que dedicar al paquete? Si tienes un tiempo muy limitado, lo mejor será que te centres en las tareas más críticas, sean las que sean para el paquete en cuestión. Si tienes mucho tiempo, tus objetivos pueden ser de mayor alcance.
-  
-  ¿Qué grado de madurez tiene el paquete? Si el paquete es maduro, es probable que mucha gente tenga código que dependa de la API del paquete (es decir, las funciones exportadas y sus parámetros). Además, si hay paquetes que dependen de tu paquete en CRAN, entonces tienes que comprobar que cualquier cambio que hagas no rompa esos paquetes. Cuanto más maduro sea el paquete, más cuidado deberás tener a la hora de hacer cambios, especialmente con los nombres de las funciones exportadas, sus parámetros y la estructura exacta de lo que devuelven las funciones exportadas. Es más fácil hacer cambios que sólo afecten a los aspectos internos del paquete.
+
+Para obtener ayuda general sobre cómo cambiar el código de un paquete, consulta la sección [Evolución del paquete](#evolution).
+
+Al pensar en esto, hay varias cosas a considerar.
+
+¿Cuánto tiempo tienes que dedicar al paquete? Si tienes un tiempo muy limitado, lo mejor será que te centres en las tareas más críticas, sean las que sean para el paquete en cuestión. Si tienes mucho tiempo, tus objetivos pueden ser más ambiciosos.
+
+¿Qué grado de madurez tiene el paquete? Si el paquete es maduro, es probable que mucha gente tenga código que dependa de su API (es decir, las funciones exportadas y sus parámetros). Además, si hay paquetes que dependen de tu paquete en CRAN, entonces tienes que comprobar que cualquier cambio que hagas no rompa esos paquetes. Cuanto más maduro sea el paquete, más cuidado deberás tener a la hora de hacer cambios, especialmente con los nombres de las funciones exportadas, sus parámetros y la estructura exacta de lo que devuelven las funciones exportadas. Es más fácil hacer cambios que sólo afecten a los aspectos internos del paquete.
 
 ## Tareas para el personal de rOpenSci
 
-Como organización, a rOpenSci le interesa asegurarse de que los paquetes de nuestro conjunto estén disponibles mientras sean útiles para la comunidad. A medida que los mantenedores tengan que seguir adelante, en la mayoría de los casos intentaremos conseguir un nuevo mantenedor para cada paquete. Para ello, las siguientes tareas son responsabilidad del personal de rOpenSci.
+Como organización, a rOpenSci le interesa asegurarse de que los paquetes de nuestra suite estén disponibles mientras sean útiles para la comunidad. Si un paquete se queda sin personas que lo mantengan, en la mayoría de los casos intentaremos conseguir nuevas personas que se encarguen del mismo. Para ello, las siguientes tareas son responsabilidad del personal de rOpenSci.
 
-- Si un repositorio no ha visto ninguna actividad (commits, issues, pull requests) en mucho tiempo, puede ser simplemente un paquete maduro con poca necesidad de cambios/etc., así que tenlo en cuenta.
-- El actual mantenedor no ha respondido a las incidencias/solicitudes de extracción en muchos meses, a través de cualquiera de los correos electrónicos, los issue de GitHub o los mensajes de Slack:
-  - Ponte en contacto con él y averigua cuál es la situación. Puede decir que le gustaría dejar de ser mantenedor, en cuyo caso busca un nuevo mantenedor
-- El actual mantenedor está completamente desaparecido/no responde
-  - Si esto ocurre, intentaremos ponernos en contacto con el mantenedor durante un máximo de un mes. Sin embargo, si la actualización del paquete es urgente, podemos utilizar nuestro acceso de administrador para realizar los cambios en su nombre.
-- Haz un llamamiento en la sección "Call for Contributors" del boletín rOpenSci para un nuevo mantenedor - abre un issue en el [repo del boletín](https://github.com/ropensci/monthly/).
-
-
+- Ten en cuenta que que un repositorio no haya visto ninguna actividad (commits, issues, pull requests) en mucho tiempo puede  significar simplemente que se trata de un paquete maduro con poca necesidad de cambios.
+- Si no hay respuestas a reportes de problemas o pull requests en muchos meses, ya sea por email, issues en GitHub o mensajes de Slack:
+  - Ponte en contacto para averiguar cuál es la situación. Puede que diga que le gustaría dejar de mantener el paquete, en cuyo caso busca un reemplazo.
+- Si no recibes respuesta o no puedes establecer el contacto:
+  - Si esto ocurre, insistiremos con el intento de contacto durante un máximo de un mes. Sin embargo, si la actualización del paquete es urgente, podemos utilizar nuestro acceso de administrador para realizar los cambios en su nombre.
+- Haz un llamado en la sección "Call for Contributors" del boletín rOpenSci para buscar reemplazo - abre un issue en el [repo del boletín](https://github.com/ropensci/monthly/).


### PR DESCRIPTION
@yabellini "Call for Contributors" section of the newsletter is mentioned here. We've translated to "Pedidos de contribuciones" but now I'm thinking that is best to keep it in English as the newsletter is written in English. 
