### PR TITLE
Missing link in 1.13 Package dependencies

### DIFF
--- a/pkg_building.Rmd
+++ b/pkg_building.Rmd
@@ -407,7 +407,7 @@ rather than one where it is re-exported. For instance many functions in **devtoo
     * Some dependencies are preferred because they provide easier to interpret
       function names and syntax than base R solutions. If this is the primary
       reason for using a function in a heavy dependency, consider wrapping
-      the base R approach in a nicely-named internal function in your package. See e.g. the [rlang R script providing functions with a syntax similar to purrr functions](https://github.com/r-lib/rlang/blob/master/R/compat-purrr.R).
+      the base R approach in a nicely-named internal function in your package. See e.g. the [rlang R script providing functions with a syntax similar to purrr functions](https://github.com/r-lib/rlang/blob/main/R/standalone-purrr.R).
 
     * If dependencies have overlapping functionality, see if you can rely on only one.
     
@@ -470,7 +470,7 @@ If you intend your package to be submitted to, or if your package is on, Biocond
 
 #### Books
 
-* [Hadley Wickham and Jenny Bryan's *R packages* book](https://r-pkgs.org/) is an excellent, readable resource on package development which is available for [free online](https://r-pkgs.org/) (and [print -- link to former version by Hadley Wickham as the new version is not published yet as of June 2022](https://www.amazon.com/Packages-Organize-Test-Document-Share/dp/1491910593)).
+* [Hadley Wickham and Jenny Bryan's *R packages* book](https://r-pkgs.org/) is an excellent, readable resource on package development which is available for [free online](https://r-pkgs.org/) (and [print -- link to former version by Hadley Wickham as the new version is not published yet as of January 2023](https://www.amazon.com/Packages-Organize-Test-Document-Share/dp/1491910593)).
 
 * [Writing R Extensions](https://cran.r-project.org/doc/manuals/r-release/R-exts.html) is the canonical, usually most up-to-date, reference for creating R packages.
 

--- a/pkg_building.es.Rmd
+++ b/pkg_building.es.Rmd
@@ -382,7 +382,7 @@ Considerar las versiones de paquetes locales como la versiones mínimas necesari
   
   - Asegúrate de que utilizas la función del paquete donde está definida originalmente y no de un paquete que la re-exporta. Por ejemplo, muchas funciones de **devtools** pueden encontrarse en paquetes especializados más pequeños, como **sessioninfo**. La función `%>%` debe importarse de **magrittr** donde está definida, en lugar de **dplyr** que la reexporta y es mucho más pesado.
   
-  - Algunas dependencias proporcionan nombres de funciones y sintaxis más fáciles de interpretar que los nombres de las funciones y la sintaxis de R base. Si ésta es la razón principal para usar una función en una dependencia pesada, considera incluir el código de R base en una función interna bien nombrada en tu paquete. Consulta, por ejemplo, el [script de R de rlang que proporciona funciones con una sintaxis similar a las funciones de purrr](https://github.com/r-lib/rlang/blob/master/R/compat-purrr.R).
+  - Algunas dependencias proporcionan nombres de funciones y sintaxis más fáciles de interpretar que los nombres de las funciones y la sintaxis de R base. Si ésta es la razón principal para usar una función en una dependencia pesada, considera incluir el código de R base en una función interna bien nombrada en tu paquete. Consulta, por ejemplo, el [script de R de rlang que proporciona funciones con una sintaxis similar a las funciones de purrr](https://github.com/r-lib/rlang/blob/main/R/standalone-purrr.R).
   
   - Si las dependencias tienen funcionalidades que se solapan, comprueba si puedes depender sólo de una.
   
@@ -443,7 +443,7 @@ Si deseas que tu paquete se envíe a Bioconductor, o si tu paquete está en Bioc
 
 #### Libros
 
-- [*R Packages* (Paquetes de R) de Hadley Wickham y Jenny Bryan](https://r-pkgs.org/) es un recurso excelente y fácil de leer sobre el desarrollo de paquetes que está disponible [gratis en línea](https://r-pkgs.org/) (e [impreso - link a la versión anterior de Hadley Wickham, ya que, hasta junio de 2022, la nueva versión aún no se ha publicado](https://www.amazon.com/Packages-Organize-Test-Document-Share/dp/1491910593)).
+- [*R Packages* (Paquetes de R) de Hadley Wickham y Jenny Bryan](https://r-pkgs.org/) es un recurso excelente y fácil de leer sobre el desarrollo de paquetes que está disponible [gratis en línea](https://r-pkgs.org/) (e [impreso - link a la versión anterior de Hadley Wickham, ya que, hasta enero de 2023, la nueva versión aún no se ha publicado](https://www.amazon.com/Packages-Organize-Test-Document-Share/dp/1491910593)).
 
 - [*Writing R Extensions* (Escribiendo extensiones de R)](https://cran.r-project.org/doc/manuals/r-release/R-exts.html) es la referencia canónica, normalmente la más actualizada, para crear paquetes de R.
 


### PR DESCRIPTION
## Original issue I found

The link at line 410 of chapter 1.13 "Packages dependencies" return an error 404.

The line in question : [here](https://github.com/ropensci/dev_guide/blob/164772cffd3265c9721fb066865e303ee1288ad4/pkg_building.Rmd#L410),  with a links to [https://github.com/r-lib/rlang/blob/main/R/compat-purrr.R](https://github.com/r-lib/rlang/blob/main/R/compat-purrr.R)

I bet this is due to a filename change in `{rlang}` github depo, for information this file is still accessible when looking for older commits. 

[Here is a version of the script](https://github.com/r-lib/rlang/blob/1216e7fcda8d887f3c3c94b4b09d3482b38fb9fb/R/compat-purrr.R), not sure if it's the version originally linked in the book. 

I also found a file named [R/standalone-purrr.R](https://github.com/r-lib/rlang/blob/main/R/standalone-purrr.R) on the main branch and I think it's the functions named in this chapter. I replaced the url but need confirmation.


## Misc

Bumped the date for *R packages* second version publication to january 2023. I can't wait for it's publication :smiley: