### PR TITLE
Change link on book release template

### DIFF
--- a/templates/book-release.md
+++ b/templates/book-release.md
@@ -18,7 +18,7 @@
 
 ### 2 weeks prior to release
 
-- [ ] Draft a blog post / tech note about the release with enough advance for editors and then Community Manager to review it (2 weeks). [Example](https://github.com/ropensci/roweb3/pull/291), [General blog post instructions](https://github.com/ropensci/roweb2#contributing-a-blog-post), [specific instructions for release posts](#releaseblogpost). 
+- [ ] Draft a blog post / tech note about the release with enough advance for editors and then Community Manager to review it (2 weeks). [Example](https://github.com/ropensci/roweb3/pull/291), [General blog post instructions](https://blogguide.ropensci.org/), [specific instructions for release posts](#releaseblogpost). 
 
 - [ ] Make a PR from the dev branch to the master branch, ping editors on GitHub and Slack. Mention the blog post draft in a comment on this PR.
 


### PR DESCRIPTION
Update with the guide to write blog post: https://blogguide.ropensci.org/

The old link point to an old version of the webpage.