### PR TITLE
Add line break between paragraph and section head

### DIFF
--- a/bot_cheatsheet.Rmd
+++ b/bot_cheatsheet.Rmd
@@ -36,6 +36,7 @@ To record your response to reviewers.
 @ropensci-review-bot submit response <response-url>
 ```
 where `<response_url>` is the link to the response comment in the issue thread.
+
 ### Finalize repo transfer {.unnumbered}
 
 After you've accepted the invitation to rOpenSci GitHub organization and transferred your GitHub repository to it, run this command to re-gain admin access to your repository.


### PR DESCRIPTION
`### Finalize repo transfer` was not recognised as a heading 3 when rendered due to a missing line break