### PR TITLE
Uses parallel construction in the COI section

### DIFF
--- a/booknews.Rmd
+++ b/booknews.Rmd
@@ -2,6 +2,7 @@
 
 ## dev (0.9.0)
 
+- 2022-04-25, changed the COI section to use parallel construction (#659, `@eliocamp
 - 2022-07-04, Add resources around GitHub workflows (#479, `@maurolepore`).
 
 - 2023-02-14, update instructions for CITATION to reflect new CRAN policies (#604, #609)

--- a/softwarereview_policies.Rmd
+++ b/softwarereview_policies.Rmd
@@ -35,10 +35,10 @@ Last but not least, you'll find the [code of conduct of rOpenSci Software Peer R
 
 Following criteria are meant to be a guide for what constitutes a conflict of interest for an editor or reviewer. The potential editor or reviewer has a conflict of interest if:
 
-* The authors with a major role are from the potential reviewer/editor's institution or institutional component (e.g., department)
-* Within in the past three years, the potential reviewer/editor has been a collaborator or has had any other professional relationship with any person on the package who has a major role
-* The potential reviewer/editor serves as a member of the advisory board for the project under review
-*  The potential reviewer/editor would receive a direct or indirect financial benefit if the package is accepted
+* The potential reviewer/editor are from the institution or institutional component (e.g., department) of any author with a major role. 
+* The potential reviewer/editor has been a collaborator or has had any other professional relationship with any person on the package who has a major role within in the past three year.
+* The potential reviewer/editor serves as a member of the advisory board for the project under review.
+* The potential reviewer/editor would receive a direct or indirect financial benefit if the package is accepted.
 * The potential reviewer/editor has significantly contributed to a competitor project.
 * There is also a lifetime COI for the family members, business partners, and thesis student/advisor or mentor.
 

--- a/softwarereview_policies.Rmd
+++ b/softwarereview_policies.Rmd
@@ -35,7 +35,7 @@ Last but not least, you'll find the [code of conduct of rOpenSci Software Peer R
 
 Following criteria are meant to be a guide for what constitutes a conflict of interest for an editor or reviewer. The potential editor or reviewer has a conflict of interest if:
 
-* The potential reviewer/editor are from the institution or institutional component (e.g., department) of any author with a major role. 
+* The potential reviewer/editor are from the same institution or institutional component (e.g., department) as any author with a major role. 
 * The potential reviewer/editor has been a collaborator or has had any other professional relationship with any person on the package who has a major role within in the past three year.
 * The potential reviewer/editor serves as a member of the advisory board for the project under review.
 * The potential reviewer/editor would receive a direct or indirect financial benefit if the package is accepted.

--- a/softwarereview_policies.Rmd
+++ b/softwarereview_policies.Rmd
@@ -37,7 +37,7 @@ Following criteria are meant to be a guide for what constitutes a conflict of in
 
 * The potential reviewer/editor are from the same institution or institutional component (e.g., department) as any author with a major role. 
 * The potential reviewer/editor has been a collaborator or has had other professional relationships with at least one person on the package who has a major role within in the past three year.
-* The potential reviewer/editor serves as a member of the advisory board for the project under review.
+* The potential reviewer/editor serves, or has served, as a member of the advisory board for the project under review.
 * The potential reviewer/editor would receive a direct or indirect financial benefit if the package were accepted.
 * The potential reviewer/editor has significantly contributed to a competitor project.
 * There is also a lifetime COI for the family members, business partners, and thesis student/advisor or mentor.

--- a/softwarereview_policies.Rmd
+++ b/softwarereview_policies.Rmd
@@ -38,7 +38,7 @@ Following criteria are meant to be a guide for what constitutes a conflict of in
 * The potential reviewer/editor are from the same institution or institutional component (e.g., department) as any author with a major role. 
 * The potential reviewer/editor has been a collaborator or has had other professional relationships with at least one person on the package who has a major role within in the past three year.
 * The potential reviewer/editor serves as a member of the advisory board for the project under review.
-* The potential reviewer/editor would receive a direct or indirect financial benefit if the package is accepted.
+* The potential reviewer/editor would receive a direct or indirect financial benefit if the package were accepted.
 * The potential reviewer/editor has significantly contributed to a competitor project.
 * There is also a lifetime COI for the family members, business partners, and thesis student/advisor or mentor.
 

--- a/softwarereview_policies.Rmd
+++ b/softwarereview_policies.Rmd
@@ -36,7 +36,7 @@ Last but not least, you'll find the [code of conduct of rOpenSci Software Peer R
 Following criteria are meant to be a guide for what constitutes a conflict of interest for an editor or reviewer. The potential editor or reviewer has a conflict of interest if:
 
 * The potential reviewer/editor are from the same institution or institutional component (e.g., department) as any author with a major role. 
-* The potential reviewer/editor has been a collaborator or has had any other professional relationship with any person on the package who has a major role within in the past three year.
+* The potential reviewer/editor has been a collaborator or has had other professional relationships with at least one person on the package who has a major role within in the past three year.
 * The potential reviewer/editor serves as a member of the advisory board for the project under review.
 * The potential reviewer/editor would receive a direct or indirect financial benefit if the package is accepted.
 * The potential reviewer/editor has significantly contributed to a competitor project.


### PR DESCRIPTION
This small PR changes the wording in the COI section so that every bulletpoint follows the same parallel construction.