### PR TITLE
Pedro review 1 of approval2template.pt.Rmd

### DIFF
--- a/approval2template.pt.Rmd
+++ b/approval2template.pt.Rmd
@@ -10,7 +10,7 @@ repo-actions: yes
 ```{r}
 #| results: 'asis'
 #| echo: false
-#| child: "templates/reviewer-approval.md"
+#| child: "templates/reviewer-approval.pt.md"
 ```
 ````
 
@@ -19,7 +19,7 @@ repo-actions: yes
 ::: {.content-visible when-format="pdf"}
 
 ```{r}
-#| child: "templates/reviewer-approval.md"
+#| child: "templates/reviewer-approval.pt.md"
 
 ```
 

--- a/approval2template.pt.Rmd
+++ b/approval2template.pt.Rmd
@@ -2,7 +2,7 @@
 repo-actions: yes
 ---
 
-# Modelo de comentário de aprovação do revisor {#approval2template}
+# Modelo de comentário de aprovação do(a) revisor(a) {#approval2template}
 
 ::: {.content-hidden when-format="pdf"}
 

--- a/templates/reviewer-approval.pt.md
+++ b/templates/reviewer-approval.pt.md
@@ -1,0 +1,11 @@
+
+## Resposta do revisor
+
+#### Aprovação final (pós-revisão)
+
+- [ ] **O autor respondeu à minha revisão e realizou as mudanças requisitadas. Eu recomendo a aprovação deste pacote.**
+
+
+<!--Por favor, preencha a estimativa abaixo.-->
+Horas estimadas gastas durante a revisão:
+

--- a/templates/reviewer-approval.pt.md
+++ b/templates/reviewer-approval.pt.md
@@ -1,9 +1,9 @@
 
-## Resposta do revisor
+## Resposta do(a) revisor(a)
 
 #### Aprovação final (pós-revisão)
 
-- [ ] **O autor respondeu à minha revisão e realizou as mudanças requisitadas. Eu recomendo a aprovação deste pacote.**
+- [ ] **O(a) autor(a) respondeu à minha revisão e realizou as mudanças requisitadas. Eu recomendo a aprovação deste pacote.**
 
 
 <!--Por favor, preencha a estimativa abaixo.-->


### PR DESCRIPTION
I made two changes considering the output of the translation API:

- Updated the paths to template documents that were referenced inside the `approval2template.pt.Rmd`;
- Manually added the translated version of the template document that was referenced inside the `approval2template.pt.Rmd`.

Following the translation policies of rOpenSci, we should do a one branch per file translated, so why did I added the translated version of the template document in this review? Because we need this template document to compile the book.
