### PR TITLE
Review 1 of Portuguese translation for `bookreleaseissue.Rmd`

### DIFF
--- a/bookreleaseissue.pt.Rmd
+++ b/bookreleaseissue.pt.Rmd
@@ -4,7 +4,7 @@ repo-actions: yes
 
 # Orientação para lançamento de livros {#bookreleaseissue}
 
-Os editores que estão se preparando para um lançamento podem executar o script `prelease.R` na pasta `inst` deste repositório para abrir automaticamente um problema no GitHub com os pontos de verificação para todos os problemas atuais atribuídos ao marco da próxima versão, juntamente com a seguinte lista de verificação.
+Os(as) editores(as) que estão se preparando para um lançamento podem executar o script `prelease.R` na pasta `inst` deste repositório para abrir automaticamente um problema no GitHub com os pontos de verificação para todos os problemas atuais atribuídos ao marco da próxima versão, juntamente com a seguinte lista de verificação.
 Antes de executar o script, verifique manualmente a atribuição de problemas ao marco.
 Isso deve ser executado um mês antes do lançamento planejado.
 

--- a/bookreleaseissue.pt.Rmd
+++ b/bookreleaseissue.pt.Rmd
@@ -4,7 +4,7 @@ repo-actions: yes
 
 # Orientação para lançamento de livros {#bookreleaseissue}
 
-Os editores que estão se preparando para um lançamento podem executar o `prelease.R` no arquivo `inst` deste repositório para abrir automaticamente um problema no GitHub com pontos de verificação para todos os problemas atuais atribuídos ao marco da próxima versão, juntamente com a seguinte lista de verificação.
+Os editores que estão se preparando para um lançamento podem executar o script `prelease.R` na pasta `inst` deste repositório para abrir automaticamente um problema no GitHub com os pontos de verificação para todos os problemas atuais atribuídos ao marco da próxima versão, juntamente com a seguinte lista de verificação.
 Antes de executar o script, verifique manualmente a atribuição de problemas ao marco.
 Isso deve ser executado um mês antes do lançamento planejado.
 

--- a/bookreleaseissue.pt.Rmd
+++ b/bookreleaseissue.pt.Rmd
@@ -14,7 +14,7 @@ Isso deve ser executado um mês antes do lançamento planejado.
 ```{r}
 #| results: 'asis'
 #| echo: false
-#| child: "templates/book-release.md"
+#| child: "templates/book-release.pt.md"
 ```
 ````
 
@@ -23,7 +23,7 @@ Isso deve ser executado um mês antes do lançamento planejado.
 ::: {.content-visible when-format="pdf"}
 
 ```{r}
-#| child: "templates/book-release.md"
+#| child: "templates/book-release.pt.md"
 
 ```
 

--- a/templates/book-release.pt.md
+++ b/templates/book-release.pt.md
@@ -10,7 +10,7 @@
 
 - [] Execute [a função `devguide_prerelease()`](https://github.com/ropensci-org/devguider) do pacote `devguider`.
 
-- [ ] Peça aos editores por qualquer feedback que você precise antes do lançamento.
+- [ ] Peça aos(às) editores(as) por qualquer feedback que você precise antes do lançamento.
 
 - [ ] Para cada contribuição/alteração verifique se as NOTÍCIAS no arquivo `Appendix.Rmd` foram atualizadas.
 
@@ -19,7 +19,7 @@
 
 ### 2 semanas antes do lançamento
 
-- [ ] Escreva um rascunho para uma postagem de blog (ou nota técnica) sobre o lançamento com antecedência suficiente para que os/as editores/as e, em seguida, o/a gerente da comunidade, possam revisá-lo (2 semanas). [Exemplo](https://github.com/ropensci/roweb3/pull/291), [instruções gerais para a postagem no blog](https://blogguide.rpensci.org/), [instruções específicas para as postagens de lançamento](#releaseblogpost).
+- [ ] Escreva um rascunho para uma postagem de blog (ou nota técnica) sobre o lançamento com antecedência suficiente para que os(as) editores(as) e, em seguida, o(a) gerente da comunidade, possam revisá-lo (2 semanas). [Exemplo](https://github.com/ropensci/roweb3/pull/291), [instruções gerais para a postagem no blog](https://blogguide.rpensci.org/), [instruções específicas para as postagens de lançamento](#releaseblogpost).
 
 - [] Crie um PR a partir da branch `dev` para a branch `master` e, em seguida, comunique aos editores através do GitHub e do Slack. Mencione o rascunho da postagem do blog em um comentário dentro deste PR.
 

--- a/templates/book-release.pt.md
+++ b/templates/book-release.pt.md
@@ -1,0 +1,39 @@
+## Release book version <insert version>
+
+### Repo maintenance between releases
+
+- [ ] Look at the issue tracker for [the dev guide](https://github.com/ropensci/dev_guide/issues) and for [software review meta](https://github.com/ropensci/software-review-meta/issues) for changes still to be made in the dev guide. Assign dev guide issues to milestones corresponding to versions, either the next one or the one after that, e.g. [version 0.3.0](https://github.com/ropensci/dev_guide/milestone/2). Encourage PRs, have them reviewed.
+
+### 1 month prior to release
+
+- [ ] Remind editors to open issues/PRs for items they want to see in the next version.
+
+- [ ] Run [the `devguide_prerelease()` function](https://github.com/ropensci-org/devguider) from the `devguider` package.
+
+- [ ] Ask editors for any feedback you need from them before release.
+
+- [ ] For each contribution/change make sure the NEWS in Appendix.Rmd were updated.
+
+- [ ] Plan a date for release in communication with rOpenSci's Community Manager who will give you a date for publishing a blog post / tech note.
+
+### 2 weeks prior to release
+
+- [ ] Draft a blog post / tech note about the release with enough advance for editors and then Community Manager to review it (2 weeks). [Example](https://github.com/ropensci/roweb3/pull/291), [General blog post instructions](https://blogguide.ropensci.org/), [specific instructions for release posts](#releaseblogpost). 
+
+- [ ] Make a PR from the dev branch to the master branch, ping editors on GitHub and Slack. Mention the blog post draft in a comment on this PR.
+
+### Release
+
+- [ ] Check URLs using [the `devguide_urls()` function from the {devguider} package](https://github.com/ropensci-org/devguider)
+
+- [ ] Check spelling using [the `devguide_spelling()` function from the {devguider} package](https://github.com/ropensci-org/devguider). Update the [WORDLIST](https://github.com/ropensci/dev_guide/blob/master/inst/WORDLIST) as necessary.
+
+- [ ] Squash and merge the PR from dev to master.
+
+- [ ] GitHub release, check Zenodo release.
+
+- [ ] Re-build (for Zenodo metadata update in the book) or wait for daily build
+
+- [ ] Re-create the dev branch
+
+- [ ] Finish your blog post / tech note PR. Underline the most important aspects to be highlighted in tweets as part of the PR discussion.

--- a/templates/book-release.pt.md
+++ b/templates/book-release.pt.md
@@ -1,39 +1,41 @@
-## Release book version <insert version>
+## Versão de lançamento do livro <insira a versão>
 
-### Repo maintenance between releases
+### Manutenção do repositório entre lançamentos
 
-- [ ] Look at the issue tracker for [the dev guide](https://github.com/ropensci/dev_guide/issues) and for [software review meta](https://github.com/ropensci/software-review-meta/issues) for changes still to be made in the dev guide. Assign dev guide issues to milestones corresponding to versions, either the next one or the one after that, e.g. [version 0.3.0](https://github.com/ropensci/dev_guide/milestone/2). Encourage PRs, have them reviewed.
+- [ ] Consulte a página de problemas para [o guia dev](https://github.com/ropensci/dev_guide/issues) e também para o repositório [de revisões de software](https://github.com/ropensci/software-review-meta/issues), procure por mudanças que ainda devem ser feitas no guia dev. Atribua os problemas encontrados no guida dev ao marco correspondente às versões, seja esta a próxima versão, ou, às versões seguintes, e.g [versão 0.3.0](https://github.com/ropensci/dev_guide/milestone/2). Encoraje novos PRs e revise eles.
 
-### 1 month prior to release
+### 1 mês antes do lançamento
 
-- [ ] Remind editors to open issues/PRs for items they want to see in the next version.
+- [ ] Lembre os editores de abrirem problemas/PRs para itens que desejam ver na próxima versão.
 
-- [ ] Run [the `devguide_prerelease()` function](https://github.com/ropensci-org/devguider) from the `devguider` package.
+- [] Execute [a função `devguide_prerelease()`](https://github.com/ropensci-org/devguider) do pacote `devguider`.
 
-- [ ] Ask editors for any feedback you need from them before release.
+- [ ] Peça aos editores por qualquer feedback que você precise antes do lançamento.
 
-- [ ] For each contribution/change make sure the NEWS in Appendix.Rmd were updated.
+- [ ] Para cada contribuição/alteração verifique se as NOTÍCIAS no arquivo `Appendix.Rmd` foram atualizadas.
 
-- [ ] Plan a date for release in communication with rOpenSci's Community Manager who will give you a date for publishing a blog post / tech note.
+- [ ] Planeje uma data para o lançamento e se comunique com o/a gerente da comunidade da rOpenSci, que lhe dará uma data para publicar uma postagem no blog (ou nota técnica).
 
-### 2 weeks prior to release
 
-- [ ] Draft a blog post / tech note about the release with enough advance for editors and then Community Manager to review it (2 weeks). [Example](https://github.com/ropensci/roweb3/pull/291), [General blog post instructions](https://blogguide.ropensci.org/), [specific instructions for release posts](#releaseblogpost). 
+### 2 semanas antes do lançamento
 
-- [ ] Make a PR from the dev branch to the master branch, ping editors on GitHub and Slack. Mention the blog post draft in a comment on this PR.
+- [ ] Escreva um rascunho para uma postagem de blog (ou nota técnica) sobre o lançamento com antecedência suficiente para que os/as editores/as e, em seguida, o/a gerente da comunidade, possam revisá-lo (2 semanas). [Exemplo](https://github.com/ropensci/roweb3/pull/291), [instruções gerais para a postagem no blog](https://blogguide.rpensci.org/), [instruções específicas para as postagens de lançamento](#releaseblogpost).
 
-### Release
+- [] Crie um PR a partir da branch `dev` para a branch `master` e, em seguida, comunique aos editores através do GitHub e do Slack. Mencione o rascunho da postagem do blog em um comentário dentro deste PR.
 
-- [ ] Check URLs using [the `devguide_urls()` function from the {devguider} package](https://github.com/ropensci-org/devguider)
+### Lançamento
 
-- [ ] Check spelling using [the `devguide_spelling()` function from the {devguider} package](https://github.com/ropensci-org/devguider). Update the [WORDLIST](https://github.com/ropensci/dev_guide/blob/master/inst/WORDLIST) as necessary.
+- [] Verifique as URLs usando [a função `devguide_urls()` do pacote {devguider}](https://github.com/ropensci-org/devguider)
 
-- [ ] Squash and merge the PR from dev to master.
+- [] Verifique a ortografia usando [a função `devguide_spelling()` do pacote {devguider}](https://github.com/rpensci-org/devguider). Atualize também a [WORDLIST](https://github.com/ropensci/dev_guide/blob/master/inst/WORDLIST) conforme necessário.
 
-- [ ] GitHub release, check Zenodo release.
+- [ ] Realize um squash sobre os seus commits para o PR de `dev` para `master`.
 
-- [ ] Re-build (for Zenodo metadata update in the book) or wait for daily build
+- [ ] Atualize a página de *release* do GitHub, e confira a página de *release* do Zenodo.
 
-- [ ] Re-create the dev branch
+- [ ] Reconstrua (para atualizar os metadados do livro no Zenodo) ou aguarde o processo diário de construção do livro.
 
-- [ ] Finish your blog post / tech note PR. Underline the most important aspects to be highlighted in tweets as part of the PR discussion.
+- [ ] Crie novamente a branch `dev`.
+
+- [ ] Conclua o PR com a sua postagem de blog (ou nota técnica). Destaque os aspectos mais importantes a serem destacados em tweets (e publicações) como parte da discussão do PR.
+

--- a/templates/book-release.pt.md
+++ b/templates/book-release.pt.md
@@ -2,7 +2,7 @@
 
 ### Manutenção do repositório entre lançamentos
 
-- [ ] Consulte a página de problemas para [o guia dev](https://github.com/ropensci/dev_guide/issues) e também para o repositório [de revisões de software](https://github.com/ropensci/software-review-meta/issues), procure por mudanças que ainda devem ser feitas no guia dev. Atribua os problemas encontrados no guida dev ao marco correspondente às versões, seja esta a próxima versão, ou, às versões seguintes, e.g [versão 0.3.0](https://github.com/ropensci/dev_guide/milestone/2). Encoraje novos PRs e revise eles.
+- [ ] Consulte a página de problemas para [o guia dev](https://github.com/ropensci/dev_guide/issues) e também para o repositório [de revisões de software](https://github.com/ropensci/software-review-meta/issues), procure por mudanças que ainda devem ser feitas no guia dev. Atribua os problemas encontrados no guia dev ao marco correspondente às versões, seja esta a próxima versão, ou, às versões seguintes, e.g [versão 0.3.0](https://github.com/ropensci/dev_guide/milestone/2). Encoraje novos PRs e revise eles.
 
 ### 1 mês antes do lançamento
 


### PR DESCRIPTION
This PR brings two main changes to the automatic output generated by the translation tools:

- Updates the template paths cited inside of `bookreleaseissue.pt.Rmd` to the translation version of the template.
- Manually add the translated version of the file `templates/book-release.pt.md`, since this template is referenced inside `bookreleaseissue.pt.Rmd`, and, therefore, it is needed for compilation of the book.