### PR TITLE
fix vdiffr phrasing

### DIFF
--- a/pkg_building.Rmd
+++ b/pkg_building.Rmd
@@ -337,7 +337,7 @@ For more explanations around licensing, refer to the [R packages book](https://r
 
 - Packages with Shiny apps should use a unit-testing framework such as [`shinytest2`](https://rstudio.github.io/shinytest2/) or [`shinytest`](https://rstudio.github.io/shinytest/articles/shinytest.html) to test that interactive interfaces behave as expected.
 
-- For testing your functions creating plots, we suggest using [vdiffr](https://cran.rstudio.com/web/packages/vdiffr/index.html), an extension of the testthat package; or [testthat snapshot tests](https://testthat.r-lib.org/articles/snapshotting.html).
+- For testing your functions creating plots, we suggest using [vdiffr](https://cran.rstudio.com/web/packages/vdiffr/index.html), an extension of the testthat package that relies on [testthat snapshot tests](https://testthat.r-lib.org/articles/snapshotting.html).
 
 - If your package interacts with web resources (web APIs and other sources of data on the web) you might find the [HTTP testing in R book by Scott Chamberlain and Maëlle Salmon](https://books.ropensci.org/http-testing/) relevant. Packages helping with HTTP testing (corresponding HTTP clients):
   

--- a/pkg_building.Rmd
+++ b/pkg_building.Rmd
@@ -337,7 +337,7 @@ For more explanations around licensing, refer to the [R packages book](https://r
 
 - Packages with Shiny apps should use a unit-testing framework such as [`shinytest2`](https://rstudio.github.io/shinytest2/) or [`shinytest`](https://rstudio.github.io/shinytest/articles/shinytest.html) to test that interactive interfaces behave as expected.
 
-- For testing your functions creating plots, we suggest using [vdiffr](https://cran.rstudio.com/web/packages/vdiffr/index.html), an extension of the testthat package that relies on [testthat snapshot tests](https://testthat.r-lib.org/articles/snapshotting.html).
+- For testing your functions creating plots, we suggest using [vdiffr](https://vdiffr.r-lib.org/), an extension of the testthat package that relies on [testthat snapshot tests](https://testthat.r-lib.org/articles/snapshotting.html).
 
 - If your package interacts with web resources (web APIs and other sources of data on the web) you might find the [HTTP testing in R book by Scott Chamberlain and Maëlle Salmon](https://books.ropensci.org/http-testing/) relevant. Packages helping with HTTP testing (corresponding HTTP clients):
   

--- a/pkg_building.es.Rmd
+++ b/pkg_building.es.Rmd
@@ -392,7 +392,7 @@ Para más detalles sobre las licencias, consulta el libro [R packages](https://r
 
 - Los paquetes con aplicaciones Shiny deberán generar *tests* unitarios usando [`shinytest2`](https://rstudio.github.io/shinytest2/) o [`shinytest`](https://rstudio.github.io/shinytest/articles/shinytest.html) para comprobar que las interfaces interactivas funcionan como es esperado.
 
-- Para testear las funciones que crean gráficos, sugerimos utilizar [vdiffr](https://cran.rstudio.com/web/packages/vdiffr/index.html), una extensión del paquete testthat que esta basada en [tests con instantáneas de testthat](https://testthat.r-lib.org/articles/snapshotting.html).
+- Para testear las funciones que crean gráficos, sugerimos utilizar [vdiffr](https://vdiffr.r-lib.org/), una extensión del paquete testthat que esta basada en [tests con instantáneas de testthat](https://testthat.r-lib.org/articles/snapshotting.html).
 
 - Si tu paquete interactúa con recursos web (APIs web y otras fuentes de datos en la web) el libro [*HTTP testing in R* (Testeando HTTP en R) de Scott Chamberlain y Maëlle Salmon](https://books.ropensci.org/http-testing/) puede resultarte relevante.
   Algunos paquetes que ayudan a realizar *tests* HTTP (y sus clientes HTTP correspondientes) son:

--- a/pkg_building.es.Rmd
+++ b/pkg_building.es.Rmd
@@ -392,7 +392,7 @@ Para más detalles sobre las licencias, consulta el libro [R packages](https://r
 
 - Los paquetes con aplicaciones Shiny deberán generar *tests* unitarios usando [`shinytest2`](https://rstudio.github.io/shinytest2/) o [`shinytest`](https://rstudio.github.io/shinytest/articles/shinytest.html) para comprobar que las interfaces interactivas funcionan como es esperado.
 
-- Para testear las funciones que crean gráficos, sugerimos utilizar [vdiffr](https://cran.rstudio.com/web/packages/vdiffr/index.html), una extensión del paquete testthat; o [tests con instantáneas de testthat](https://testthat.r-lib.org/articles/snapshotting.html).
+- Para testear las funciones que crean gráficos, sugerimos utilizar [vdiffr](https://cran.rstudio.com/web/packages/vdiffr/index.html), una extensión del paquete testthat que esta basada en [tests con instantáneas de testthat](https://testthat.r-lib.org/articles/snapshotting.html).
 
 - Si tu paquete interactúa con recursos web (APIs web y otras fuentes de datos en la web) el libro [*HTTP testing in R* (Testeando HTTP en R) de Scott Chamberlain y Maëlle Salmon](https://books.ropensci.org/http-testing/) puede resultarte relevante.
   Algunos paquetes que ayudan a realizar *tests* HTTP (y sus clientes HTTP correspondientes) son:


### PR DESCRIPTION
Fix #294

The vdiffr README now explicitly mentions it's based on snapshot tests, so the two things aren't different options.