### PR TITLE
Update editor workflow to reflect read-only Airtable

### DIFF
--- a/softwarereview_editor.Rmd
+++ b/softwarereview_editor.Rmd
@@ -77,26 +77,13 @@ When these sources of information are not enough,
 
 ##### Tips for reviewer search in Airtable {#tips-for-reviewer-search-in-airtable}
 
-Your tools for searching reviewers in the Airtable are
-
-- filters (please remove them once you're done), see example below.
+You can use filters, sorting, and search to identify reviewers with particular experience:
 
 ![Screenshot of the Airtable filters interface with a filter on domain expertise that has to include chemistry and technical areas that have to include continuous integration](images/airtable.png)
 
-* creating a personal [view](https://support.airtable.com/hc/en-us/articles/202624989-Guide-to-views), depending on your Airtable skills.
-
-Have a look at the `last_time_contacted` and `last_answer` columns before contacting someone!
-If someone recently refused because they were busy, it might be best to abstain, whereas someone who refused because of a COI could be contacted again without waiting too long.
-
-Also, please check if a first-time reviewers have indicated that they `require_mentorship`.  If so, please use the mentorship portion of the email template and be prepared to provide additional guidance.
-
-##### Storing information from the reviewer search in Airtable {#airtable-info}
-
-For people listed in the Airtable, if you contact them about a review please update the `last_time_contacted` column, and enter the category corresponding to their answer in `last_answer`.
-
-Only add people to Airtable if they accept to review (otherwise, people should volunteer themselves by filling the Airtable form).
-Do not enter any information other than GitHub username, name and email address yourself.
-Point reviewers to the [Airtable form](https://ropensci.org/software-reviewer).
+Please check the reviewer's most recent review and avoid anyone who has reviewed anyone in the past six months.
+Also, please check if a first-time reviewers have indicated that they `require_mentorship`.
+If so, please use the mentorship portion of the email template and be prepared to provide additional guidance.
 
 ##### Criteria for choosing a reviewer {#criteria-for-choosing-a-reviewer}
 

--- a/softwarereview_editor.Rmd
+++ b/softwarereview_editor.Rmd
@@ -73,7 +73,7 @@ When these sources of information are not enough,
 - look for users of the package or of the data source/upstream service the package connects to (via their opening issues in the repository, starring it, citing it in papers, talking about it on Twitter).
 - You can also search for authors of related packages on [r-pkg.org](https://r-pkg.org/).
 - R-Ladies has a [directory](https://rladies.org/directory/) specifying skills and interests of people listed.
-- You might tweet about the reviewer search.
+- You may post a request for reviewers in the #general and/or #software-review channels on the rOpenSci Slack, or on social media.
 
 ##### Tips for reviewer search in Airtable {#tips-for-reviewer-search-in-airtable}
 

--- a/softwarereview_editor.es.Rmd
+++ b/softwarereview_editor.es.Rmd
@@ -68,7 +68,7 @@ Cuando estas fuentes de información no sean suficientes,
 - busca personas que usen el paquete o de la fuente de datos o servicio al que se conecta el paquete (a través de la apertura de *issues* en el repositorio, destacándolo, citándolo en artículos, hablando de él en redes sociales).
 - También puedes buscar personas con paquetes relacionados en [r-pkg.org](https://r-pkg.org/).
 - R-Ladies tiene un [directorio](https://rladies.org/directory/) en el que se especifican las aptitudes e intereses de las personas incluidas en la lista.
-- Puedes publicar una solicitud de revisores en los canales #general y/o #software-review del Slack de rOpenSci, o en las redes sociales.
+- Puedes publicar la búsqueda en los canales #general y/o #software-review del Slack de rOpenSci, o en las redes sociales.
 
 ##### Consejos para la búsqueda en Airtable {#tips-for-reviewer-search-in-airtable}
 

--- a/softwarereview_editor.es.Rmd
+++ b/softwarereview_editor.es.Rmd
@@ -77,7 +77,7 @@ Puedes utilizar filtros, clasificación y búsqueda para identificar personas pa
 ![Captura de pantalla de la interfaz de filtros de Airtable con un filtro sobre experiencia en disciplinas que debe incluir química y en conocimientos técnicos que tienen que incluir integración continua](images/airtable.png)
 
 Comprueba la revisión más reciente de la persona y evita a cualquiera que haya revisado en los últimos seis meses.
-Asimismo, comprueba si una persona que es nueva revisando ha indicado que `require_mentorship`.
+Asimismo, comprueba si una persona que es nueva revisando ha indicado que requiere tutoría en el campo`require_mentorship`.
 En caso afirmativo, utiliza la parte de tutoría de la plantilla de correo electrónico y prepárate para proporcionar orientación adicional.
 
 ##### Criterios para elegir a las personas que harán la revisión {#criteria-for-choosing-a-reviewer}

--- a/softwarereview_editor.es.Rmd
+++ b/softwarereview_editor.es.Rmd
@@ -70,28 +70,17 @@ Cuando estas fuentes de información no sean suficientes,
 - R-Ladies tiene un [directorio](https://rladies.org/directory/) en el que se especifican las aptitudes e intereses de las personas incluidas en la lista.
 - Puedes publicar la búsqueda en las redes sociales.
 
-##### Consejos para la búsqueda en Airtable {#tips-for-reviewer-search-in-airtable}*Airtable*
+- Puedes tuitear sobre la búsqueda de revisores.
 
-Tus herramientas para buscar personas para la revisión en *Airtable* son
+##### Consejos para la búsqueda de revisores en Airtable {#tips-for-reviewer-search-in-airtable}
 
-- filtros (por favor, elimínalos una vez que hayas terminado), ver ejemplo más abajo.
+Puedes utilizar los filtros, la clasificación y la búsqueda para identificar a los revisores con una experiencia concreta:
 
-![Captura de pantalla de la interfaz de filtros de Airtable con un filtro sobre conocimientos técnicos que tiene que incluir química y en áreas técnicas tienen que incluir integración continua (interfaz y etiquetas en inglés)](images/airtable.png)
+![Captura de pantalla de la interfaz de filtros de Airtable con un filtro sobre experiencia en dominios que tienen que incluir la química y áreas técnicas que tienen que incluir la integración continua](images/airtable.png)
 
-- crear una [visualización personalizada](https://support.airtable.com/hc/en-us/articles/202624989-Guide-to-views) dependiendo de tus habilidades en Airtable.
-
-Echa un vistazo a los campos `last_time_contacted` (último contacto) y `last_answer` (última respuesta) antes de ponerte en contacto con alguien.
-Si alguien se ha negado recientemente porque no tenía tiempo, podría ser mejor abstenerse, mientras que no hace falta esperar demasiado para volver a invitar a alguien que se negó debido a conflictos de interés.
-
-Además, comprueba si una persona que es nueva revisando ha indicado que `require_mentorship`.  En caso afirmativo, utiliza la parte de tutoría de la plantilla de correo electrónico y prepárate para proporcionar orientación adicional.
-
-##### Almacenar la información de la búsqueda en Airtable  {#airtable-info}
-
-Si contactas a alguien desde Airtable, actualiza el campo `last_time_contacted` e introduce la categoría correspondiente a su respuesta en `last_answer`.
-
-Sólo añade personas a Airtable si aceptan revisar (de lo contrario, las personas deben ofrecerse voluntariamente rellenando el formulario de Airtable).
-No introduzcas más información que su nombre de usuario de GitHub, su nombre y su dirección de correo electrónico.
-Pide a quienes que podrían potencialmente revisar que completen el [formulario de Airtable](https://ropensci.org/software-reviewer).
+Comprueba la opinión más reciente del revisor y evita a cualquiera que haya revisado a alguien en los últimos seis meses.
+Asimismo, comprueba si un revisor primerizo ha indicado que `require_mentorship`.
+En caso afirmativo, utiliza la parte de tutoría de la plantilla de correo electrónico y prepárate para proporcionar orientación adicional.
 
 ##### Criterios para elegir a las personas que harán la revisión {#criteria-for-choosing-a-reviewer}
 

--- a/softwarereview_editor.es.Rmd
+++ b/softwarereview_editor.es.Rmd
@@ -70,16 +70,16 @@ Cuando estas fuentes de información no sean suficientes,
 - R-Ladies tiene un [directorio](https://rladies.org/directory/) en el que se especifican las aptitudes e intereses de las personas incluidas en la lista.
 - Puedes publicar la búsqueda en las redes sociales.
 
-- Puedes tuitear sobre la búsqueda de revisores.
+- Puedes publicar la búsqueda en las redes sociales.
 
-##### Consejos para la búsqueda de revisores en Airtable {#tips-for-reviewer-search-in-airtable}
+##### Consejos para la búsqueda en Airtable {#tips-for-reviewer-search-in-airtable}
 
-Puedes utilizar los filtros, la clasificación y la búsqueda para identificar a los revisores con una experiencia concreta:
+Puedes utilizar filtros, clasificación y búsqueda para identificar personas para la revisión con una experiencia concreta:
 
-![Captura de pantalla de la interfaz de filtros de Airtable con un filtro sobre experiencia en dominios que tienen que incluir la química y áreas técnicas que tienen que incluir la integración continua](images/airtable.png)
+![Captura de pantalla de la interfaz de filtros de Airtable con un filtro sobre experiencia en disciplinas que debe incluir química y en conocimientos técnicos que tienen que incluir integración continua](images/airtable.png)
 
-Comprueba la opinión más reciente del revisor y evita a cualquiera que haya revisado a alguien en los últimos seis meses.
-Asimismo, comprueba si un revisor primerizo ha indicado que `require_mentorship`.
+Comprueba la revisión más reciente de la persona y evita a cualquiera que haya revisado en los últimos seis meses.
+Asimismo, comprueba si una persona que es nueva revisando ha indicado que `require_mentorship`.
 En caso afirmativo, utiliza la parte de tutoría de la plantilla de correo electrónico y prepárate para proporcionar orientación adicional.
 
 ##### Criterios para elegir a las personas que harán la revisión {#criteria-for-choosing-a-reviewer}

--- a/softwarereview_editor.es.Rmd
+++ b/softwarereview_editor.es.Rmd
@@ -68,9 +68,7 @@ Cuando estas fuentes de información no sean suficientes,
 - busca personas que usen el paquete o de la fuente de datos o servicio al que se conecta el paquete (a través de la apertura de *issues* en el repositorio, destacándolo, citándolo en artículos, hablando de él en redes sociales).
 - También puedes buscar personas con paquetes relacionados en [r-pkg.org](https://r-pkg.org/).
 - R-Ladies tiene un [directorio](https://rladies.org/directory/) en el que se especifican las aptitudes e intereses de las personas incluidas en la lista.
-- Puedes publicar la búsqueda en las redes sociales.
-
-- Puedes publicar la búsqueda en las redes sociales.
+- Puedes publicar una solicitud de revisores en los canales #general y/o #software-review del Slack de rOpenSci, o en las redes sociales.
 
 ##### Consejos para la búsqueda en Airtable {#tips-for-reviewer-search-in-airtable}
 


### PR DESCRIPTION
Part of #688

We previously requested editors keep notes on reviewer outreach in the AirTable, but data stability, privacy and price-related reasons this database is no longer manually editable.  This PR updates editor workflow and guidance to reflect this.