### PR TITLE
Review for Portuguese translation of `preface.Rmd`

### DIFF
--- a/preface.pt.Rmd
+++ b/preface.pt.Rmd
@@ -36,6 +36,6 @@ cat("\n```\n")
 
 *Se você quiser contribuir com este livro (sugestões, correções), consulte [o repositório do GitHub](https://github.com/ropensci/dev_guide) em particular [as diretrizes de contribuição](https://github.com/ropensci/dev_guide#contributing). Obrigado a você!*
 
-*Somos gratos a todos os autores, revisores e editores convidados por nos ajudarem a aprimorar o sistema e este guia ao longo dos anos. Agradecemos também às seguintes pessoas que fizeram contribuições para este guia e suas versões anteriores: `r readLines("thanks.md")` Informe-nos se esquecemos de reconhecer a sua contribuição!*
+*Agradecemos a todos os autores, revisores e editores convidados por nos ajudarem a aprimorar o sistema e este guia ao longo dos anos. Agradecemos também às seguintes pessoas que fizeram contribuições para este guia e suas versões anteriores: `r readLines("thanks.md")` Informe-nos se esquecemos de reconhecer a sua contribuição!*
 
 

--- a/preface.pt.Rmd
+++ b/preface.pt.Rmd
@@ -6,19 +6,19 @@ repo-actions: true
 
 Boas vindas! Este livro é um guia para autores, mantenedores, revisores e editores da rOpenSci.
 
-O livro [primeira seção do livro](#building) contém nossas diretrizes para criar e testar os pacotes do R.
+A [primeira seção do livro](#building) contém as nossas diretrizes para criar e testar pacotes do R.
 
-A seção [segunda seção](#softwarereviewintro) é dedicada ao processo de revisão por pares de software da rOpenSci: o que é, nossas políticas e guias específicos para autores, editores e revisores durante todo o processo. Para *revisão de software estatístico* consulte a seção [página da Web e recursos do projeto](https://ropensci.org/stat-software-review/).
+A [segunda seção](#softwarereviewintro) é dedicada ao processo de revisão por pares de software da rOpenSci: o que é esse processo, quais são as nossas políticas e guias específicos para autores, editores e revisores durante todo o processo. Para *revisão de software estatístico*, consulte a [página da Web e os recursos do projeto](https://ropensci.org/stat-software-review/).
 
-A página [terceira e última seção](#collaboration) apresenta nossas práticas recomendadas para você cuidar do seu pacote depois que ele tiver sido integrado: como colaborar com outros desenvolvedores, como documentar lançamentos, como promover seu pacote e como aproveitar o GitHub como uma plataforma de desenvolvimento. A terceira seção também apresenta um [capítulo para quem deseja começar a contribuir com os pacotes do rOpenSci](#contributingguide).
+A [terceira e última seção](#collaboration) apresenta as nossas práticas recomendadas para você cuidar do seu pacote depois que ele tiver sido integrado: como colaborar com outros desenvolvedores, como documentar lançamentos, como promover o seu pacote e como aproveitar o GitHub como uma plataforma de desenvolvimento. A terceira seção também apresenta um [capítulo para quem deseja começar a contribuir com os pacotes do rOpenSci](#contributingguide).
 
-Esperamos que você ache o guia útil e claro, e agradecemos suas sugestões no [rastreador de problemas do livro](https://github.com/ropensci/dev_guide/issues). Feliz embalagem R!
+Esperamos que você ache o guia útil e claro, e agradecemos suas sugestões no [*issue tracker* do livro](https://github.com/ropensci/dev_guide/issues). Feliz embalagem R!
 
 A equipe editorial da rOpenSci.
 
 Este livro é um documento vivo.
-Você pode ver as atualizações das nossas práticas recomendadas e políticas no site [notas de versão](#booknews).  
-Você pode citar este livro usando [seus metadados Zenodo e DOI](https://doi.org/10.5281/zenodo.2553043).
+Você pode ver as atualizações das nossas práticas recomendadas e políticas nas [notas de versão](#booknews).  
+Você pode citar este livro usando [os metadados Zenodo e DOI](https://doi.org/10.5281/zenodo.2553043).
 
 ````{r}
 #| echo: false

--- a/preface.pt.Rmd
+++ b/preface.pt.Rmd
@@ -34,8 +34,8 @@ cat(bibentry)
 cat("\n```\n")
 ````
 
-*Se você quiser contribuir com este livro (sugestões, correções), consulte [o repositório do GitHub](https://github.com/ropensci/dev_guide) em particular [as diretrizes de contribuição](https://github.com/ropensci/dev_guide#contributing). Obrigado a você!*
+*Se você quiser contribuir com este livro (sugestões, correções), consulte [o repositório do GitHub](https://github.com/ropensci/dev_guide) em particular [as diretrizes de contribuição](https://github.com/ropensci/dev_guide#contributing). Obrigado!*
 
-*Agradecemos a todos os autores, revisores e editores convidados por nos ajudarem a aprimorar o sistema e este guia ao longo dos anos. Agradecemos também às seguintes pessoas que fizeram contribuições para este guia e suas versões anteriores: `r readLines("thanks.md")` Informe-nos se esquecemos de reconhecer a sua contribuição!*
+*Agradecemos a todos os autores, revisores e editores convidados por nos ajudarem a aprimorar  o  sistema e este guia ao longo dos anos. Agradecemos também às seguintes pessoas que fizeram contribuições para este guia e suas versões anteriores: `r readLines("thanks.md")` Informe-nos se esquecemos de reconhecer a sua contribuição!*
 
 

--- a/preface.pt.Rmd
+++ b/preface.pt.Rmd
@@ -4,7 +4,7 @@ repo-actions: true
 
 # Prefácio {.unnumbered}
 
-Você é bem-vindo! Este livro é um guia para autores, mantenedores, revisores e editores da rOpenSci.
+Boas vindas! Este livro é um guia para autores, mantenedores, revisores e editores da rOpenSci.
 
 O livro [primeira seção do livro](#building) contém nossas diretrizes para criar e testar os pacotes do R.
 


### PR DESCRIPTION
This PR brings three change to the automatic output generated by the translation tools:

- Fix small typos in few sentences;
- Add @beatrizmilz suggestion;
- Revert translation of "issue tracker", which was translated to "rastreador de problemas".