### PR TITLE
Issue #786: get html text directly

### DIFF
--- a/index.Rmd
+++ b/index.Rmd
@@ -14,7 +14,7 @@ u <- "https://zenodo.org/record/2553043" # universal URL redirects to latest
 s <- rvest::session(u)
 u <- paste0(s$url, "/export/bibtex") # redirected
 out <- rvest::read_html(u)
-bibentry <- rvest::html_text(rvest::html_element(out, "pre"))
+bibentry <- rvest::html_text(out)
 cat(bibentry)
 cat("\n```\n")
 ```


### PR DESCRIPTION
This is reflecting a change in the Zenodo API.

https://help.zenodo.org/docs/about/whats-changed/

Closes #786.
Closes #716.