### PR TITLE
Add paragraph on avoiding overlap between package website and CRAN package vignettes

### DIFF
--- a/pkg_building.Rmd
+++ b/pkg_building.Rmd
@@ -297,7 +297,7 @@ If your package doesn't have any logo, the [rOpenSci docs builder](#docsropensci
 
 ### Avoid duplication with CRAN package vignettes
 
-If your package on CRAN and you also have a package website then try to avoid duplication. Having the same vignettes in both places leads to inconsistencies as both are not always updated simultaneously, which leads to ambiguity about where the real package documentation should be found. Ideally you should have one place for all your documentation. Further, make sure your CRAN vignettes clearly link to your website. To ensure that website vignettes do not end up on CRAN add these vignettes to your `.Rbuildignore` file.
+If your package is on CRAN and you also have a package website then try to avoid duplication. Having the same vignettes in both places leads to inconsistencies as both are not always updated simultaneously, which leads to ambiguity about where the real package documentation should be found. Ideally you should have one place for all your documentation. Further, make sure your CRAN vignettes clearly link to your website. To ensure that website vignettes do not end up on CRAN add these vignettes to your `.Rbuildignore` file.
 
 ## Authorship {#authorship}
 

--- a/pkg_building.Rmd
+++ b/pkg_building.Rmd
@@ -295,6 +295,10 @@ template:
 To use your package logo in the pkgdown homepage, refer to [`usethis::use_logo()`](https://usethis.r-lib.org/reference/use_logo.html).
 If your package doesn't have any logo, the [rOpenSci docs builder](#docsropensci) will use rOpenSci logo instead.
 
+### Avoid duplication with CRAN package vignettes
+
+If your package on CRAN and you also have a package website then try to avoid duplication. Having the same vignettes in both places leads to inconsistencies as both are not always updated simultaneously, which leads to ambiguity about where the real package documentation should be found. Ideally you should have one place for all your documentation. Further, make sure your CRAN vignettes clearly link to your website.
+
 ## Authorship {#authorship}
 
 The `DESCRIPTION` file of a package should list package authors and contributors to a package, using the `Authors@R` syntax to indicate their roles (author/creator/contributor etc.) if there is more than one author, and using the comment field to indicate the ORCID ID of each author, if they have one (cf [this post](https://ropensci.org/technotes/2018/10/08/orcid/)). See [this section of "Writing R Extensions"](https://cran.rstudio.com/doc/manuals/r-release/R-exts.html#The-DESCRIPTION-file) for details.  If you feel that your reviewers have made a substantial contribution to the development of your package, you may list them in the `Authors@R` field with a Reviewer contributor type (`"rev"`), like so:

--- a/pkg_building.Rmd
+++ b/pkg_building.Rmd
@@ -297,7 +297,7 @@ If your package doesn't have any logo, the [rOpenSci docs builder](#docsropensci
 
 ### Avoid duplication with CRAN package vignettes
 
-If your package on CRAN and you also have a package website then try to avoid duplication. Having the same vignettes in both places leads to inconsistencies as both are not always updated simultaneously, which leads to ambiguity about where the real package documentation should be found. Ideally you should have one place for all your documentation. Further, make sure your CRAN vignettes clearly link to your website.
+If your package on CRAN and you also have a package website then try to avoid duplication. Having the same vignettes in both places leads to inconsistencies as both are not always updated simultaneously, which leads to ambiguity about where the real package documentation should be found. Ideally you should have one place for all your documentation. Further, make sure your CRAN vignettes clearly link to your website. To ensure that website vignettes do not end up on CRAN add these vignettes to your `.Rbuildignore` file.
 
 ## Authorship {#authorship}
 


### PR DESCRIPTION
Hello, I would like to propose a new paragraph to discourage duplication of vignettes between CRAN vignettes (if package is on CRAN) and package website.

**Background on why I propose this:**
For a package that I maintain we have elaborate documentation in CRAN vignettes ([link](https://cran.r-project.org/web/packages/GGIR/vignettes/GGIR.html)). They have evolved over the years and are the key resource for the package users. However, as you know, the limitation of CRAN vignettes is that they cannot be updated without having to make an entire new package release. Therefore, I am now transitioning to having a package website (with pkgdown) that hosts most of the documentation complemented by CRAN vignettes that are only brief and that reference the website. I think that using the same vignette for the website would be confusing since it is then unclear what the real latest documentation is given that both are not updated simultaneously. Most likely the CRAN vignettes will always run behind with the package website. But even if both would be identical then it still looks messy to have two locations for the same information. So, I think the best solution is to discourage duplication of information between CRAN and website, and to have a link from CRAN to website.

Note: As this is a small update I did not create an issue.