### PR TITLE
Review for Portuguese translation of `newstemplate.Rmd`

### DIFF
--- a/newstemplate.pt.Rmd
+++ b/newstemplate.pt.Rmd
@@ -6,7 +6,7 @@ repo-actions: true
 
 ````markdown
 ```{r}
-#| child: "templates/news.md"
+#| child: "templates/news.pt.md"
 ```
 ````
 

--- a/templates/news.pt.md
+++ b/templates/news.pt.md
@@ -1,0 +1,35 @@
+foobar 0.2.0 (2016-04-01)
+=========================
+
+### NOVAS FUNCIONALIDADES
+
+  * Nova função adicionada `do_things()` para fazer coisas (#5)
+
+### MELHORIAS PEQUENAS
+
+  * Documentação foi aprimorada para a função `things()` (#4)
+
+### CORREÇÕES DE BUGS
+
+  * Correção de um bug de parseamento em `parse()` (#3)
+
+### DEPRECADO E EXTINTO
+
+  * `hello_world()` está deprecada agora e será removida em
+     uma futura versão, utilize `hello_mars()`
+
+### CORREÇÕES EM DOCUMENTAÇÃO
+
+  * Papel de `hello_mars()` versus `goodbye_mars()` está melhor esclarecido.
+
+
+### (um especial: qualquer cabeçalho que agrupa um número grande de mudanças sobre uma única coisa)
+
+    * blablabla.
+
+foobar 0.1.0 (2016-01-01)
+=========================
+
+### NOVAS FUNCIONALIDADES
+
+  * lançamento no CRAN


### PR DESCRIPTION
The first review adds one change to the automatic translation output:

- Add the translated version of the template that is referenced from within the document.