### PR TITLE
Remove incorrect sentence

### DIFF
--- a/maintenance_evolution.Rmd
+++ b/maintenance_evolution.Rmd
@@ -226,6 +226,6 @@ An example of a minimal README in an archived package is in [ropensci-archive/mo
 - [ ] Archive the repository on GitHub (also under repo settings).
 - [ ] Transfer the repository to [ropensci-archive](https://github.com/ropensci-archive), or request an [rOpenSci staff member](https://ropensci.org/about/#team) to transfer it (you can email `info@ropensci.org`).
 
-Archived packages may be unarchived if authors or a new person opt to resume maintenance. For that please contact rOpenSci. They are transferred to the ropenscilabs organization.
+Archived packages may be unarchived if authors or a new person opt to resume maintenance. For that please contact rOpenSci. 
 
 

--- a/maintenance_evolution.es.Rmd
+++ b/maintenance_evolution.es.Rmd
@@ -236,6 +236,6 @@ Una vez que el *README* se ha copiado en otro lugar y se ha reducido a su forma 
 - [ ] Transfiere el repositorio a [ropensci-archive](https://github.com/ropensci-archive) o solicita a un [miembro del equipo de rOpenSci](https://ropensci.org/about/#team) que lo haga (puedes enviar un correo electrónico a `info@ropensci.org`).
 
 Los paquetes archivados pueden ser desarchivados si quien lo mantenía, o una nueva persona, deciden reanudar el mantenimiento.
-Para ello, ponte en contacto con rOpenSci y se transferirá el repo a la organización ropenscilabs.
+Para ello, ponte en contacto con rOpenSci.
 
 


### PR DESCRIPTION
The last sentence of maintenance_evolution repeated something on the check-list with a different organization name. I think it can be removed to avoid confusion. 