### PR TITLE
Add first review for `softwarereview_editor_management.Rmd`

### DIFF
--- a/softwarereview_editor_management.pt.Rmd
+++ b/softwarereview_editor_management.pt.Rmd
@@ -1,11 +1,12 @@
 ---
-aliases: editorialmanagement.html
+aliases:
+  - editorialmanagement.html
 ---
 
 # Gerenciamento editorial {#editorialmanagement}
 
 ```{block, type="summaryblock"}
-Orientação para gerenciar a equipe editorial.
+Orientações para gerenciar a equipe editorial.
 ```
 
 ## Recrutamento de novos editores {#recruiting-new-editors}
@@ -16,16 +17,16 @@ Etapas:
 
 - Inicie um canal privado para discussão (para que você não tenha um histórico no canal de editores no qual futuros editores entrarão, o que pode ser incômodo).
 
-- Faça ping nos editores para garantir que eles recebam uma notificação, pois esse é um tópico importante.
+- Marque os editores na conversa para garantir que eles recebam uma notificação, pois este é um tópico importante.
 
 - Espere que a maioria dos editores se manifeste antes de convidar alguém. Dê a eles uma semana para responder.
 
-## Convidando um novo editor {#inviting-a-new-editor}
+## Convidando um(a) novo(a) editor(a) {#inviting-a-new-editor}
 
-- Os candidatos podem começar por ser [editores convidados](#guesteditor).
-  Ao convidá-los como editores convidados, convide-os da mesma forma que você convidaria um editor convidado por outros motivos.
+- Um(a) candidato(a) pode começar como um(a) [editor(a) convidado(a)](#guesteditor).
+  Ao convidá-lo como um(a) editor(a) convidado(a), convide-o da mesma forma que você convidaria um(a) editor(a) convidado(a) por outros motivos.
 
-- Se um candidato for o primeiro editor convidado, avalie como foi o processo após o envio. Peça novamente a opinião de outros editores.
+- Se um(a) candidato(a) começar como um(a) editor(a) convidado(a), avalie como foi o processo após a submissão. Peça novamente a opinião de outros editores.
 
 - Envie um e-mail.
 
@@ -53,50 +54,51 @@ Best,
 [EDITOR], on behalf of the rOpenSci Editorial Board
 ```
 
-## Integração de um novo editor {#onboarding-a-new-editor}
+## Integrando um(a) novo(a) editor(a) ao time {#onboarding-a-new-editor}
 
 - Informe o gerente da comunidade rOpenSci para que
   
-  - editores sejam adicionados à lista de [site da rOpenSci](https://github.com/ropensci/roweb3/#team-member).
-  - Você pode criar uma postagem de introdução no blog.
+  - novos editores sejam adicionados ao [site da rOpenSci](https://github.com/ropensci/roweb3/#team-member).
+  - Você pode criar um novo post no blog da rOpenSci para introduzir os novos editores.
 
-- Se eles ainda não o fizeram como editores convidados, solicite que o novo editor ative o [a autenticação de dois fatores (2FA) para o GitHub](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa).
+- Se eles ainda não fizeram este passo como editores convidados, solicite aos novos editores que ativem [a autenticação de dois fatores (2FA) para o GitHub](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa).
 
-- Convide editores para a organização do rOpenSci no GitHub como membro, como membro da equipe de editores do rOpenSci. [`editors` equipe](https://github.com/orgs/ropensci/teams/editors) e da equipe [`data-pkg-editors`](https://github.com/orgs/ropensci/teams/data-pkg-editors) ou [`stats-board`](https://github.com/orgs/ropensci/teams/stats-board) ou subequipe, conforme apropriado.  Isso dará a eles as permissões apropriadas e permitirá que recebam notificações específicas da equipe.
+- Convide os novos editores para integrar a organização da rOpenSci no GitHub como membro da [equipe de editores da rOpenSci](https://github.com/orgs/ropensci/teams/editors) e da equipe [`data-pkg-editors`](https://github.com/orgs/ropensci/teams/data-pkg-editors) ou [`stats-board`](https://github.com/orgs/ropensci/teams/stats-board) subequipe, conforme for apropriado.  Isso dará a eles as permissões apropriadas e vai permitir que eles recebam notificações específicas da equipe.
 
-- Os editores precisam acessar o banco de dados AirTable de revisão de software.
+- Os editores precisam acessar o banco de dados sobre revisão de software na AirTable.
 
 - Os editores precisam ter acesso ao canal privado de editores no espaço de trabalho do Slack da rOpenSci (e ao espaço de trabalho do Slack em geral, caso não o tenham feito anteriormente; nesse caso, peça ao gerente da comunidade da rOpenSci).
 
-- Publique uma mensagem de boas-vindas no canal, enviando um ping para todos os editores.
+- Publique uma mensagem de boas-vindas aos novos editores no canal, marcando todos os editores na mensagem.
 
-- No espaço de trabalho do Slack, eles precisam ser adicionados à equipe de editores para que `@editors` você também os contatará.
+- No espaço de trabalho do Slack, os novos editores precisam ser adicionados à "equipe de editores" para que sejam notificados também quando alguém marcar uma mensagem com `@editors`.
 
-- Adicionamos os nomes dos editores a
+- Adicionar os nomes dos novos editores a/ao:
   
-  - [lista de autores do guia dev](https://github.com/ropensci/dev_guide/blob/main/index.Rmd)
-  - [capítulo do guia dev introduzindo a análise de software](https://github.com/ropensci/dev_guide/blob/main/softwarereview_intro.Rmd) (em dois locais neste arquivo, como editores e um pouco abaixo para removê-los da lista de revisores)
+  - [lista de autores do Guia Dev](https://github.com/ropensci/dev_guide/blob/main/index.Rmd)
+  - [capítulo do Guia Dev que introduz a revisão de software](https://github.com/ropensci/dev_guide/blob/main/softwarereview_intro.Rmd) (em dois locais neste arquivo, como editores e um pouco abaixo para removê-los da lista de revisores)
   - [software-review README](https://github.com/ropensci/software-review/blob/main/README.Rmd) (em dois lugares nesse arquivo também)
-    Tanto o guia do desenvolvedor quanto o LEIAME da revisão do software são automaticamente inseridos por meio da integração contínua.
+    Tanto o Guia Dev quanto o README da revisão de software são automaticamente compilados por meio do processo de integração contínua.
 
-- Adicione editores a [https://github.com/orgs/ropensci/teams/editors/members](https://github.com/orgs/ropensci/teams/editors/members)
+- Adicione os novos editores à [https://github.com/orgs/ropensci/teams/editors/members](https://github.com/orgs/ropensci/teams/editors/members)
 
-## Desvinculação de um editor {#offboarding-an-editor}
 
-- Agradeça a ele por seu trabalho!
+## Desvincular um(a) editor(a) {#offboarding-an-editor}
 
-- Remova-os do canal somente para editores e da equipe de editores do Slack.
+- Agradeça o(a) editor(a) por seu trabalho!
 
-- Remova-os de [https://github.com/orgs/ropensci/teams/editors/members](https://github.com/orgs/ropensci/teams/editors/members) e da subequipe.
+- Remova este(a) editor(a) do canal reservado para editores, e também da "equipe de editores" do Slack.
 
-- Informe o gerente da comunidade do rOpenSci ou outro membro da equipe para que eles possam ser transferidos para os membros da equipe de ex-alunos no site.
+- Remova este(a) editor(a) de [https://github.com/orgs/ropensci/teams/editors/members](https://github.com/orgs/ropensci/teams/editors/members) e da subequipe.
+
+- Informe o gerente da comunidade do rOpenSci ou outro membro da equipe para que este(a) editor(a) possa ser transferido(a) para a parte de ex-membros no site da rOpenSci.
 
 - Remova o acesso deles ao espaço de trabalho do Airtable.
 
 - Removê-los do
   
-  - [capítulo do guia do desenvolvedor que apresenta a revisão do software](https://github.com/ropensci/dev_guide/blob/main/softwarereview_intro.Rmd) (em dois locais neste arquivo, como editores e um pouco abaixo para removê-los da lista de revisores)
+  - [capítulo do Guia Dev que apresenta a revisão de software](https://github.com/ropensci/dev_guide/blob/main/softwarereview_intro.Rmd) (em dois locais neste arquivo, como editores e um pouco abaixo para removê-los da lista de revisores)
   - [software-review README](https://github.com/ropensci/software-review/blob/main/README.Rmd) (em dois lugares nesse arquivo também)
-    Tanto o guia do desenvolvedor quanto o LEIAME da revisão do software são automaticamente inseridos por meio da integração contínua.
+    Tanto o Guia Dev quanto o README da revisão de software são automaticamente compilados por meio do processo de integração contínua.
 
 

--- a/softwarereview_editor_management.pt.Rmd
+++ b/softwarereview_editor_management.pt.Rmd
@@ -1,7 +1,4 @@
----
-aliases:
-  - editorialmanagement.html
----
+ 
 
 # Gerenciamento editorial {#editorialmanagement}
 


### PR DESCRIPTION
This PR adds the first review for the portuguese translation of the file `softwarereview_editor_management.Rmd`. The following changes were made:

- Some sentences were rephrased to keep to original meaning from the english version of the text.
- When a sentence includes the word "editor" in singular, this word was transformed into "editor(a)", to be more gender-neutral.
- When a sentence includes the word "editores", which is the plural version of "editor", the word is kept intact (as is). Because in Portuguese, the word "editores" is used to refer to a group of editors in general, despite their gender.