### PR TITLE
metadata for translations

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -18,7 +18,7 @@ description-es: |
       La tercera sección también incluye un capítulo para cualquiera que desee
       comenzar a contribuir a los paquetes de rOpenSci.
 title-pt: "Pacotes rOpenSci: Desenvolvimento, manutenção e revisão por pares"
-author-pt: "Equipe editorial para a revisão de software rOpenSci (atual e anterior): Brooke Anderson, Scott Chamberlain, Laura DeCicco, Julia Gustavsen, Jeff Hollister, Anna Krystalli, Mauro Lepore, Lincoln Mullen, Mark Padgham, Karthik Ram, Emily Riederer, Noam Ross, Maëlle Salmon, Adam Sparks, Melina Vidoni"
+author-pt: "Equipe editorial para a revisão de software rOpenSci (atual e anterior)"
 description-pt: |
     Guia para pessoas autoras, responsáveis, revisoras e editoras de pacotes no
     sistema de revisão por pares da rOpenSci.

--- a/index.es.Rmd
+++ b/index.es.Rmd
@@ -1,6 +1,6 @@
 # Guía de desarrollo de rOpenSci {.unnumbered}
 
-<a href="https://doi.org/10.5281/zenodo.2553043"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.2553043.svg?branch=master" alt="DOI"></a>
+<a href="https://doi.org/10.5281/zenodo.10797248"><img src="https://zenodo.org/badge/DOI/10.5281/zenodo.10797249.svg" alt="DOI"></a>
 
 <a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/3.0/us/deed.es"><img alt="Licencia Creative Commons" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/us/88x31.png" /></a><br /> Esta obra está bajo [una Licencia Creative Commons Atribución-NoComercial-CompartirIgual 3.0 Estados Unidos de América](https://creativecommons.org/licenses/by-nc-sa/3.0/us/deed.es). Consulta [el DOI de Zenodo](https://doi.org/10.5281/zenodo.2553043) de la version original y [el DOI de la traducción](https://zenodo.org/doi/10.5281/zenodo.10797248) para saber como citarlas.
 

--- a/index.pt.Rmd
+++ b/index.pt.Rmd
@@ -4,11 +4,12 @@
 
 <a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/3.0/us/"><img alt="Licença Creative Commons" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/3.0/us/88x31.png" /></a><br /> Este trabalho está licenciado com uma licença [Creative Commons Attribution-NonCommercial-ShareAlike 3.0 United States License](https://creativecommons.org/licenses/by-nc-sa/3.0/us/). Utilize o [Zenodo DOI](https://doi.org/10.5281/zenodo.2553043) para citar esta obra.
 
-```{r}
-#| echo: false
-#| results: 'asis' 
-#| warning: false
-source(file.path("scripts", "zenodo.R"), local = knitr::knit_global())
+
+Exemplo
+
+```
+rOpenSci editorial team (2024). Pacotes rOpenSci: Desenvolvimento, manutenção e revisão por pares [rOpenSci Packages: Development, Maintenance, and Peer Review] (Tradução para o português: Pedro Faria, Beatriz Milz, Francesca Palmeira, Samuel Carleial, Marcelo S. Perlin,  Ariana Cabral, Ildeberto Vasconcelos, Daniel Vartanian, Rafael Fontenelle, João Granja-Correia) Zenodo. https://doi.org/10.5281/zenodo.2553043 (Trabalho original publicado em 2025)
+
 ```
 
 Você também pode ler a [versão em PDF](/ropensci-dev-guide.pdf) deste livro.


### PR DESCRIPTION
Fix #917

@yabellini I still have questions about the Zenodo entry.

- How did we create the Zenodo entry for the Spanish translation? In particular, where did we store the ORCID IDs of the translators?
- Related, how should we create the Zenodo entry for the Portuguese translation? How do we get a Zenodo URL before the first release :zany_face: 
