### PR TITLE
Update softwarereview_editor_management.Rmd

### DIFF
--- a/softwarereview_editor_management.Rmd
+++ b/softwarereview_editor_management.Rmd
@@ -65,7 +65,7 @@ Best,
 
 - Invite editors to the rOpenSci GitHub organization as member, as a member of the [`editors` team](https://github.com/orgs/ropensci/teams/editors) and the [`data-pkg-editors`](https://github.com/orgs/ropensci/teams/data-pkg-editors) or [`stats-board`](https://github.com/orgs/ropensci/teams/stats-board) sub-team, as appropriate.  This will give them appropriate permissions and allow them to get team-specific notifications.
 
-- Editors need access to the AirTable database of software review.
+- Editors need access to the AirTable database of software review (see link in the description of the editors-only channel on Slack).
 
 - Editors need access to the private editors channel in rOpenSci Slack workspace (and to the Slack workspace in general if they didn't previously, in that case ask rOpenSci community manager).
 

--- a/softwarereview_editor_management.Rmd
+++ b/softwarereview_editor_management.Rmd
@@ -65,7 +65,7 @@ Best,
 
 - Invite editors to the rOpenSci GitHub organization as member, as a member of the [`editors` team](https://github.com/orgs/ropensci/teams/editors) and the [`data-pkg-editors`](https://github.com/orgs/ropensci/teams/data-pkg-editors) or [`stats-board`](https://github.com/orgs/ropensci/teams/stats-board) sub-team, as appropriate.  This will give them appropriate permissions and allow them to get team-specific notifications.
 
-- Editors need access to the AirTable database of software review (see link in the description of the editors-only channel on Slack).
+- Editors need access to the AirTable database of software review (linked in the description of the editors-only channel on Slack).
 
 - Editors need access to the private editors channel in rOpenSci Slack workspace (and to the Slack workspace in general if they didn't previously, in that case ask rOpenSci community manager).
 

--- a/softwarereview_editor_management.es.Rmd
+++ b/softwarereview_editor_management.es.Rmd
@@ -60,7 +60,7 @@ Te deseamos lo mejor,
 
 - Invítalo a la organización GitHub de rOpenSci y a los equipos [`editors`](https://github.com/orgs/ropensci/teams/editors) y  [`data-pkg-editors`](https://github.com/orgs/ropensci/teams/data-pkg-editors) o [`stats-board`](https://github.com/orgs/ropensci/teams/stats-board), según corresponda. Esto le dará los permisos adecuados y le permitirá recibir notificaciones específicas del equipo.
 
-- Dale acceso a la base de datos de revisión de software de AirTable.
+- Dale acceso a la base de datos de revisión de software de AirTable (enlazada en la descripción del canal 'editors-only' en Slack).
 
 - Dale acceso al canal privado del equipo editorial en el espacio de trabajo de Slack de rOpenSci (y al espacio de trabajo de Slack en general si no lo tenía previamente, en ese caso pregunta a quien maneja la comunidad de rOpenSci).
 

--- a/softwarereview_editor_management.pt.Rmd
+++ b/softwarereview_editor_management.pt.Rmd
@@ -62,7 +62,7 @@ Atenciosamente,
 
 - Convide os novos editores para integrar a organização da rOpenSci no GitHub como membro da [equipe de editores da rOpenSci](https://github.com/orgs/ropensci/teams/editors) e da equipe [`data-pkg-editors`](https://github.com/orgs/ropensci/teams/data-pkg-editors) ou [`stats-board`](https://github.com/orgs/ropensci/teams/stats-board) subequipe, conforme for apropriado.  Isso dará a eles as permissões apropriadas e vai permitir que eles recebam notificações específicas da equipe.
 
-- Os editores precisam acessar o banco de dados sobre revisão de software na AirTable.
+- Os editores precisam acessar o banco de dados sobre revisão de software na AirTable(vinculado na descrição do canal apenas para editores do Slack).
 
 - Os editores precisam ter acesso ao canal privado de editores no espaço de trabalho do Slack da rOpenSci (e ao espaço de trabalho do Slack em geral, caso não o tenham feito anteriormente; nesse caso, peça ao gerente da comunidade da rOpenSci).
 

--- a/softwarereview_editor_management.pt.Rmd
+++ b/softwarereview_editor_management.pt.Rmd
@@ -62,7 +62,7 @@ Atenciosamente,
 
 - Convide os novos editores para integrar a organização da rOpenSci no GitHub como membro da [equipe de editores da rOpenSci](https://github.com/orgs/ropensci/teams/editors) e da equipe [`data-pkg-editors`](https://github.com/orgs/ropensci/teams/data-pkg-editors) ou [`stats-board`](https://github.com/orgs/ropensci/teams/stats-board) subequipe, conforme for apropriado.  Isso dará a eles as permissões apropriadas e vai permitir que eles recebam notificações específicas da equipe.
 
-- Os editores precisam acessar o banco de dados sobre revisão de software na AirTable(vinculado na descrição do canal apenas para editores do Slack).
+- Os editores precisam acessar o banco de dados sobre revisão de software no AirTable (o link está na descrição do canal `editors-only` no Slack).
 
 - Os editores precisam ter acesso ao canal privado de editores no espaço de trabalho do Slack da rOpenSci (e ao espaço de trabalho do Slack em geral, caso não o tenham feito anteriormente; nesse caso, peça ao gerente da comunidade da rOpenSci).
 


### PR DESCRIPTION
Here's a suggestion that may help new editors more easily find the right tab to search for reviewers.

If we go forward with these change, then we'll need to remember to update the guides in each lenguage:

- [x] English
- [x] Spanish
- [x] Portuguese

Thanks @ronnyhdez for feedback :pray: 


---

Without details it seems easy to get lost in Airtable, e.g. I may land in this table with `reviews` and `reviewers` tabs:

<img width="1504" height="168" alt="Image" src="https://github.com/user-attachments/assets/888483ab-dc17-43a1-b0cd-ac78ce3c515e" />

Maybe we could add a link to [here](https://airtable.com/app8dssb6a7PG6Vwj/pagDnNgnYqa9VY93y)?

<img width="1504" height="140" alt="image" src="https://github.com/user-attachments/assets/ef9dd372-30cc-407e-b5ea-0974bbbb2993" />

But for easier maintainability, this PR  instead points to the description of the editors-only channel.