### PR TITLE
Update pkg_building.Rmd

### DIFF
--- a/pkg_building.Rmd
+++ b/pkg_building.Rmd
@@ -350,7 +350,7 @@ Many packages include code from other software. Whether entire files or single f
 The package needs to have a [CRAN](https://svn.r-project.org/R/trunk/share/licenses/license.db) or [OSI](https://opensource.org/licenses) accepted license.
 The [R packages book](https://r-pkgs.org/description.html#sec-description-authors-at-r) includes a helpful [section on licenses](https://r-pkgs.org/license.html).
 
-If your package bundles code from other sources, you also need to acknowledge authors of the original code in your DESCIPTION file, generally with a copyright-holder role: `role = "cph"`.
+If your package bundles code from other sources, you also need to acknowledge authors of the original code in your DESCRIPTION file, generally with a copyright-holder role: `role = "cph"`.
 For how to update your DESCRIPTION file, see the [R packages book](https://r-pkgs.org/description.html#sec-description-authors-at-r).
 
 ## Testing {#testing}


### PR DESCRIPTION
I edited a typo in the line 353, changing “DESCIPTION” to “DESCRIPTION.”



----

Checklist for dev guide maintainers, do not delete :smile_cat:

- [ ] Review of the content in the initial language.
- [ ] News item.
- [ ] Translation of the content in other languages.
- [ ] Review of the translations.
