### PR TITLE
Update pkg_building.es.Rmd

### DIFF
--- a/pkg_building.es.Rmd
+++ b/pkg_building.es.Rmd
@@ -389,7 +389,7 @@ Tanto si se incluyen archivos enteros como funciones individuales de otros paque
 El paquete debe tener una licencia aceptada por [CRAN](https://svn.r-project.org/R/trunk/share/licenses/license.db) u [OSI](https://opensource.org/licenses).
 El libro [*R packages* (Paquetes de R)](https://r-pkgs.org/description.html#sec-description-authors-at-r) incluye una sección muy útil sobre licencias.
 
-Si tu paquete incluye código de otras fuentes, también necesitas reconocer a los autores del código original en tu archivo DESCIPTION, generalmente con un rol de propietario del copyright: `role = "cph"`.
+Si tu paquete incluye código de otras fuentes, también necesitas reconocer a los autores del código original en tu archivo DESCRIPTION, generalmente con un rol de propietario del copyright: `role = "cph"`.
 Para saber cómo actualizar tu archivo DESCRIPTION, consulta el libro [*R packages* (Paquetes de R)](https://r-pkgs.org/description.html#sec-description-authors-at-r) en Inglés o puedes consultar también el libro en español [Introducción a la programación II](https://intro-programacion.netlify.app/09_paquetes-1.html#completando-el-archivo-description).
 
 ## Testeo {#testing}


### PR DESCRIPTION
I edited a typo in the line 392, changing “DESCIPTION” to “DESCRIPTION.”



----

Checklist for dev guide maintainers, do not delete :smile_cat:

- [ ] Review of the content in the initial language.
- [ ] News item.
- [ ] Translation of the content in other languages.
- [ ] Review of the translations.
