### PR TITLE
Update news.es.md - corrected some typos

### DIFF
--- a/templates/news.es.md
+++ b/templates/news.es.md
@@ -1,7 +1,7 @@
 foobar 0.2.0 (2016-04-01)
 =========================
 
-### Nueva functionalidad
+### Nueva funcionalidad
 
   * Nueva función `hacer_algo()` para hacer cosas. (#5)
 
@@ -15,7 +15,7 @@ foobar 0.2.0 (2016-04-01)
 
 ### Obsoleto y caucado
 
-  * `hola_mundo()` ahora es una función obsoleta y se eliminará en un en una versión futura, utiliza `hola_marte()`.
+  * `hola_mundo()` ahora es una función obsoleta y se eliminará en una versión futura, utiliza `hola_marte()`.
 
 ### Correcciones a la documentación
 
@@ -28,6 +28,6 @@ foobar 0.2.0 (2016-04-01)
 foobar 0.1.0 (2016-01-01)
 =========================
 
-### Nueva functionalidad
+### Nueva funcionalidad
 
   * publicado en CRAN.


### PR DESCRIPTION
News in Spanish may have some typos derived from the English translation. 



----

Checklist for dev guide maintainers, do not delete :smile_cat:

- [ ] Review of the content in the initial language.
- [ ] News item.
- [ ] Translation of the content in other languages.
- [ ] Review of the translations.
