### PR TITLE
add comment on updating Airtable rev-prod for new editors

### DIFF
--- a/booknews.Rmd
+++ b/booknews.Rmd
@@ -2,6 +2,7 @@
 
 ## Dev version
 
+- 2026-05-21, add comment on updating Airtable rev-prod for new editors (#1005).
 - 2026-04-10, two fixes to roxygen2 tags mentions (#1000, #1001, `@Pakillo`). Now 4 digits for PRs and issues!
 
 ## 1.0.0

--- a/scripts/airtable-get-data.R
+++ b/scripts/airtable-get-data.R
@@ -24,13 +24,13 @@ at_guest <- airtabler::airtable(base = "app8dssb6a7PG6Vwj",
                                  table = "guest-editors")
 
 
-editor_index_all <- purrr::map_lgl(reviewers$editor, ~!is.null(.))
+editor_index_all <- purrr::map_lgl(reviewers$editor, ~!is.null(.) && !any(is.na(.)))
 editors_all <- reviewers[which(editor_index_all), c("name", "github", "Affiliation", "editor")]
 editors_all <- editors_all [which(!editors_all$name == eic_name), ]
 last_names <- humaniformat::last_name(trimws(editors_all$name))
 editors_all <- editors_all[order(last_names), ]
 
-editors_past <- editors_all[grep("Emeritus", editors_all$editor), ]
+editors_past <- editors_all[grep("Emeritus|On\\sLeave", editors_all$editor), ]
 editors <- editors_all[which(!editors_all$name %in% editors_past$name), ]
 
 guest_editors <- at_guest$`guest-editors`$select_all()

--- a/scripts/airtable-get-data.R
+++ b/scripts/airtable-get-data.R
@@ -24,7 +24,7 @@ at_guest <- airtabler::airtable(base = "app8dssb6a7PG6Vwj",
                                  table = "guest-editors")
 
 
-editor_index_all <- purrr::map_lgl(reviewers$editor, ~!is.null(.) && !any(is.na(.)))
+editor_index_all <- purrr::map_lgl(reviewers$editor, ~!is.null(.) && !anyNA(.))
 editors_all <- reviewers[which(editor_index_all), c("name", "github", "Affiliation", "editor")]
 editors_all <- editors_all [which(!editors_all$name == eic_name), ]
 last_names <- humaniformat::last_name(trimws(editors_all$name))

--- a/softwarereview_editor_management.Rmd
+++ b/softwarereview_editor_management.Rmd
@@ -66,6 +66,8 @@ Best,
 - Invite them to the AirTable database of software review (linked in the description of the editors-only channel on Slack).
   Ensure invitation is "Read only".
 
+- Update the "editor" field in the Airtable "reviewers-prod" table (this is used to identify and list current editors within this _Dev Guide_).
+
 - Invite them to the private "editors-only" channel in rOpenSci's Slack workspace (and to the Slack workspace in general if they're not yet there).
 
 - Once they're in the "editors-only" channel, post a welcome message pinging all editors.

--- a/softwarereview_editor_management.Rmd
+++ b/softwarereview_editor_management.Rmd
@@ -89,6 +89,8 @@ Best,
   - Click "Share" button on top right, and then "People with access"
   - Click checkbox on left on editor to be removed, and "Remove 1 collaborator".
 
+- Change their "editor" label in the Airtable "reviewers-prod" data to "Emeritus"
+
 - The (past-)editors lists in both the [dev\_guide chapter introducing software review](https://github.com/ropensci/dev_guide/blob/main/softwarereview_intro.Rmd) and the [software-review README](https://github.com/ropensci/software-review/blob/main/README.Rmd) are automatically populated from the AirTable data.
   Updates are run daily, so check a day after AirTable updates to ensure both have been updated.
   

--- a/softwarereview_editor_management.es.Rmd
+++ b/softwarereview_editor_management.es.Rmd
@@ -87,7 +87,7 @@ Te deseamos lo mejor,
   - Haz clic en el botón "_Share_ (compartir)" de la parte superior derecha, y luego en "_People with access_ (personas con acceso)"
   - Haz clic en la casilla de la izquierda de la persona que quieras remover y luego en "_Remove 1 collaborator_ (remover 1 colaborador/a)".
 
-- Cambia su etiqueta "editor" en los datos "reviewers-prod" de Airtable a "Emérito"
+- Cambia su etiqueta "editor" a "Emérito", en los datos "reviewers-prod" de Airtable 
 - Las listas de integrantes del equipo editorial, tanto en el [capítulo de introducción a la revisión del software en la guía](https://github.com/ropensci/dev_guide/blob/main/softwarereview_intro.Rmd) como en el [README del repo de revisión de software](https://github.com/ropensci/software-review/blob/main/README.Rmd), se completan automáticamente a partir de los datos de AirTable.
   Las actualizaciones se ejecutan diariamente, así que compruébalo un día después de actualizar AirTable para asegurarte de que ambos se hayan actualizado.
 

--- a/softwarereview_editor_management.es.Rmd
+++ b/softwarereview_editor_management.es.Rmd
@@ -2,7 +2,6 @@
 aliases:
   - editorialmanagement.html
 ---
-
 # Gestión editorial  {#editorialmanagement}
 
 ```{block, type="summaryblock"}
@@ -66,6 +65,7 @@ Te deseamos lo mejor,
 - Envíale una invitación a la base de datos de Airtable de revisión de software (enlazada en la descripción del canal sólo para editores en Slack).
   Asegúrate de que la invitación es "Sólo lectura".
 
+- Actualiza el campo "editor" en la tabla "reviewers-prod" de Airtable (se utiliza para identificar y listar a los editores actuales dentro de este *Guía de desarrollo*).
 - Dale acceso al canal privado "editors-only" del espacio de trabajo Slack de rOpenSci (y al espacio de trabajo Slack en general si aún no están allí).
 
 - Una vez que esté en el canal "editors-only", envía un mensaje de bienvenida con un ping a todas las personas editoras.
@@ -87,6 +87,7 @@ Te deseamos lo mejor,
   - Haz clic en el botón "_Share_ (compartir)" de la parte superior derecha, y luego en "_People with access_ (personas con acceso)"
   - Haz clic en la casilla de la izquierda de la persona que quieras remover y luego en "_Remove 1 collaborator_ (remover 1 colaborador/a)".
 
+- Cambia su etiqueta "editor" en los datos "reviewers-prod" de Airtable a "Emérito"
 - Las listas de integrantes del equipo editorial, tanto en el [capítulo de introducción a la revisión del software en la guía](https://github.com/ropensci/dev_guide/blob/main/softwarereview_intro.Rmd) como en el [README del repo de revisión de software](https://github.com/ropensci/software-review/blob/main/README.Rmd), se completan automáticamente a partir de los datos de AirTable.
   Las actualizaciones se ejecutan diariamente, así que compruébalo un día después de actualizar AirTable para asegurarte de que ambos se hayan actualizado.
 

--- a/softwarereview_editor_management.es.Rmd
+++ b/softwarereview_editor_management.es.Rmd
@@ -65,7 +65,7 @@ Te deseamos lo mejor,
 - Envíale una invitación a la base de datos de Airtable de revisión de software (enlazada en la descripción del canal sólo para editores en Slack).
   Asegúrate de que la invitación es "Sólo lectura".
 
-- Actualiza el campo "editor" en la tabla "reviewers-prod" de Airtable (se utiliza para identificar y listar a los editores actuales dentro de este *Guía de desarrollo*).
+- Actualiza el campo "editor" en la tabla "reviewers-prod" de Airtable (se utiliza para identificar y listar a las personas que son parte del equipo editorial actual dentro de esta *Guía de desarrollo*).
 - Dale acceso al canal privado "editors-only" del espacio de trabajo Slack de rOpenSci (y al espacio de trabajo Slack en general si aún no están allí).
 
 - Una vez que esté en el canal "editors-only", envía un mensaje de bienvenida con un ping a todas las personas editoras.

--- a/softwarereview_editor_management.pt.Rmd
+++ b/softwarereview_editor_management.pt.Rmd
@@ -87,7 +87,7 @@ Atenciosamente,
   - Clique no botão "Share" (Compartilhar) no canto superior direito e, em seguida, em "People with access" (Pessoas com acesso)
   - Clique na caixa de seleção à esquerda do(a) editor(a) a ser removido(a) e em "Remove 1 collaborator" (Remover 1 colaborador/a).
 
-- Alterar o rótulo "editor" nos dados "reviewers-prod" do Airtable para "Emérito"
+- Alterar o rótulo "editor" para "Emérito" nos dados "reviewers-prod" do Airtable 
 - As listas de editores (anteriores) em ambos os capítulos do [dev\_guide que apresenta a revisão de software](https://github.com/ropensci/dev_guide/blob/main/softwarereview_intro.Rmd) e do [software-review README](https://github.com/ropensci/software-review/blob/main/README.Rmd) são preenchidos automaticamente a partir dos dados do AirTable.
   As atualizações são executadas diariamente, portanto, verifique um dia após as atualizações do AirTable para garantir que ambos tenham sido atualizados.
 

--- a/softwarereview_editor_management.pt.Rmd
+++ b/softwarereview_editor_management.pt.Rmd
@@ -2,7 +2,6 @@
 aliases:
   - editorialmanagement.html
 ---
-
 # Gerenciamento editorial {#editorialmanagement}
 
 ```{block, type="summaryblock"}
@@ -66,6 +65,7 @@ Atenciosamente,
 - Convide-os para o banco de dados AirTable de análise de software (vinculado na descrição do canal, somente para editores, no Slack).
   Certifique-se de que o convite seja "Somente leitura".
 
+- Atualize o campo "editor" na tabela "reviewers-prod" do Airtable (isso é usado para identificar e listar os editores atuais nessa tabela). *Guia do desenvolvedor*).
 - Convide-os para o canal privado "editors-only" no espaço de trabalho Slack da rOpenSci (e para o espaço de trabalho Slack em geral, se eles ainda não estiverem lá).
 
 - Quando eles estiverem no canal "editors-only", publique uma mensagem de boas-vindas informando todos os editores.
@@ -87,6 +87,7 @@ Atenciosamente,
   - Clique no botão "Share" (Compartilhar) no canto superior direito e, em seguida, em "People with access" (Pessoas com acesso)
   - Clique na caixa de seleção à esquerda do(a) editor(a) a ser removido(a) e em "Remove 1 collaborator" (Remover 1 colaborador/a).
 
+- Alterar o rótulo "editor" nos dados "reviewers-prod" do Airtable para "Emérito"
 - As listas de editores (anteriores) em ambos os capítulos do [dev\_guide que apresenta a revisão de software](https://github.com/ropensci/dev_guide/blob/main/softwarereview_intro.Rmd) e do [software-review README](https://github.com/ropensci/software-review/blob/main/README.Rmd) são preenchidos automaticamente a partir dos dados do AirTable.
   As atualizações são executadas diariamente, portanto, verifique um dia após as atualizações do AirTable para garantir que ambos tenham sido atualizados.
 


### PR DESCRIPTION
@maelle The change to https://github.com/ropensci/dev_guide/blob/main/scripts/airtable-get-data.R is key - some `editor` values are `NA`, and these are retained and listed as editors at https://devguide.ropensci.org/softwarereview_intro.html#editorial-team. The Airtable fields are empty, just like the standard NULL ones, so I don't know where the `NA`s come from, but this fixes. I've also updated all Airtable records, and added extra lines to instructions on what I did there. This should fix the list.

(Oh, and we currently have only one ed on leave, Anna Krystalli, and she's cool with being unlisted there; there'll likely be another soon joining the indefinite-leave crew, but treating them as Emeritus in this context is fine.)

----

Checklist for dev guide maintainers, do not delete :smile_cat:

- [x] Review of the content in the initial language.
- [x] News item.
- [x] Translation of the content in other languages.
- [ ] Review of the translations.
