### PR TITLE
'guia' matches the chapter name; also link it

### DIFF
--- a/templates/review.es.md
+++ b/templates/review.es.md
@@ -32,7 +32,7 @@ El paquete incluye todos los siguientes tipos de documentación:
 - [ ] **Funcionalidad:** Se confirmaron todas las afirmaciones de funcionalidad.
 - [ ] **Desempeño:** Se confirmaron todas las afirmaciones de desempeño.
 - [ ] **Pruebas automáticas:** Hay *tests* unitarios que cubren las funciones esenciales dentro del paquete con un rango razonable de entradas y condiciones. Todas las pruebas corren correctamente en la computadora local.
-- [ ] **Directrices de empaquetado:** El paquete cumple la [guía de empaquetado de rOpenSci(https://devdevguide.netlify.app/es/pkg_building.es).
+- [ ] **Directrices de empaquetado:** El paquete cumple la [guía de empaquetado de rOpenSci](https://devdevguide.netlify.app/es/pkg_building.es).
 
 Estimación de horas dedicadas a la revisión:
 

--- a/templates/review.es.md
+++ b/templates/review.es.md
@@ -32,7 +32,7 @@ El paquete incluye todos los siguientes tipos de documentación:
 - [ ] **Funcionalidad:** Se confirmaron todas las afirmaciones de funcionalidad.
 - [ ] **Desempeño:** Se confirmaron todas las afirmaciones de desempeño.
 - [ ] **Pruebas automáticas:** Hay *tests* unitarios que cubren las funciones esenciales dentro del paquete con un rango razonable de entradas y condiciones. Todas las pruebas corren correctamente en la computadora local.
-- [ ] **Directrices de empaquetado:** El paquete cumple la [guía de empaquetado de rOpenSci](https://devdevguide.netlify.app/es/pkg_building.es).
+- [ ] **Directrices de empaquetado:** El paquete cumple la [guía de empaquetado de rOpenSci](#building).
 
 Estimación de horas dedicadas a la revisión:
 

--- a/templates/review.es.md
+++ b/templates/review.es.md
@@ -32,7 +32,7 @@ El paquete incluye todos los siguientes tipos de documentación:
 - [ ] **Funcionalidad:** Se confirmaron todas las afirmaciones de funcionalidad.
 - [ ] **Desempeño:** Se confirmaron todas las afirmaciones de desempeño.
 - [ ] **Pruebas automáticas:** Hay *tests* unitarios que cubren las funciones esenciales dentro del paquete con un rango razonable de entradas y condiciones. Todas las pruebas corren correctamente en la computadora local.
-- [ ] **Directrices de empaquetado:** El paquete cumple las directrices de empaquetado de rOpenSci.
+- [ ] **Directrices de empaquetado:** El paquete cumple la [guía de empaquetado de rOpenSci(https://devdevguide.netlify.app/es/pkg_building.es).
 
 Estimación de horas dedicadas a la revisión:
 

--- a/templates/review.md
+++ b/templates/review.md
@@ -31,7 +31,7 @@ The package includes all the following forms of documentation:
 - [ ] **Functionality:** Any functional claims of the software have been confirmed.
 - [ ] **Performance:** Any performance claims of the software have been confirmed.
 - [ ] **Automated tests:** Unit tests cover essential functions of the package and a reasonable range of inputs and conditions. All tests pass on the local machine.
-- [ ] **Packaging guidelines**: The package conforms to the [rOpenSci packaging guidelines](#building).
+- [ ] **Packaging guidelines**: The package conforms to the [rOpenSci packaging guide](#building).
 
 Estimated hours spent reviewing:
 

--- a/templates/review.md
+++ b/templates/review.md
@@ -31,7 +31,7 @@ The package includes all the following forms of documentation:
 - [ ] **Functionality:** Any functional claims of the software have been confirmed.
 - [ ] **Performance:** Any performance claims of the software have been confirmed.
 - [ ] **Automated tests:** Unit tests cover essential functions of the package and a reasonable range of inputs and conditions. All tests pass on the local machine.
-- [ ] **Packaging guidelines**: The package conforms to the rOpenSci packaging guidelines.
+- [ ] **Packaging guidelines**: The package conforms to the [rOpenSci packaging guidelines](#building).
 
 Estimated hours spent reviewing:
 

--- a/templates/review.pt.md
+++ b/templates/review.pt.md
@@ -31,7 +31,7 @@ O pacote inclui todas as seguintes formas de documentação:
 - [ ] **Funcionalidade:** Qualquer funcionalidade que foi assumida pelo software foi confirmada.
 - [ ] **Desempenho:** Qualquer desempenho a mais que foi assumido pelo software foi confirmado.
 - [ ] **Testes automatizados:**Os testes unitários cobrem funções essenciais do pacote e uma gama razoável de *inputs* e condições. Todos os testes passam na máquina local.
-- [ ] **Diretrizes de empacotamento**: O pacote está em conformidade com as diretrizes de empacotamento da rOpenSci.
+- [ ] **Diretrizes de empacotamento**: O pacote está em conformidade com as [diretrizes de empacotamento da rOpenSci](#building).
 
 Horas estimadas gastas na revisão:
 

--- a/templates/review.pt.md
+++ b/templates/review.pt.md
@@ -31,7 +31,7 @@ O pacote inclui todas as seguintes formas de documentação:
 - [ ] **Funcionalidade:** Qualquer funcionalidade que foi assumida pelo software foi confirmada.
 - [ ] **Desempenho:** Qualquer desempenho a mais que foi assumido pelo software foi confirmado.
 - [ ] **Testes automatizados:**Os testes unitários cobrem funções essenciais do pacote e uma gama razoável de *inputs* e condições. Todos os testes passam na máquina local.
-- [ ] **Diretrizes de empacotamento**: O pacote está em conformidade com as [diretrizes de empacotamento da rOpenSci](#building).
+- [ ] **Diretrizes de empacotamento**: O pacote está em conformidade com o [guia de desenvolvimento de pacotes da rOpenSci](#building).
 
 Horas estimadas gastas na revisão:
 


### PR DESCRIPTION
This change responds to feedback from one of our champions, who
found the word 'directrices' unclear. To make it clear I propose
to a) link the chapter we refer to and b) reword 'directrices' to
'guia' to match the wording of the chapter title.

I'm not 100% sure the link is the one we intend.

Note I did not add the equivalent link to other templates. Happy to
do it if this seems like a useful change.



----

Checklist for dev guide maintainers, do not delete :smile_cat:

- [ ] Review of the content in the initial language.
- [ ] News item.
- [ ] Translation of the content in other languages.
- [ ] Review of the translations.
