### PR TITLE
add git guidance and news item

### DIFF
--- a/booknews.Rmd
+++ b/booknews.Rmd
@@ -2,6 +2,8 @@
 
 ## Dev version
 
+- 2026-09-07, add recommendations and resources about Git commits (#1006).
+- 2026-09-07, add first AI policies (#1006).
 - 2026-08-24, mention `NEWS.md` file in packaging guide (#1027).
 - 2026-08-24, fix lifecycle badge (`@joelnitta`, #1030).
 - 2026-06-26, explicitely state that authors should not change their package while it is under review (#1022).

--- a/pkg_building.Rmd
+++ b/pkg_building.Rmd
@@ -557,6 +557,12 @@ For how to update your DESCRIPTION file, see the [R packages book](https://r-pkg
 - Your package source files have to be under version control, more specifically tracked with [Git](https://happygitwithr.com/). 
   You might find the [gert package](https://docs.ropensci.org/gert/) relevant, as well as some of [usethis Git/GitHub related functionality](https://usethis.r-lib.org/reference/index.html#section-git-and-github); you can however use git as you want.
 
+- Small, informative Git commits allow to better understand and debug a project. Do not group too many unrelated changes in a single commit; avoid using meaningless commit messages such as "update" or "commit". We do not require a clean Git history, but we highly recommend making an effort. Useful resources:
+    - ["Write Better Commits, Build Better Projects"](https://github.blog/developer-skills/github/write-better-commits-build-better-projects/);
+    - ["Why you need small, informative Git commits"](https://masalmon.eu/2024/06/03/small-commits/);
+    - ["Hack your way to a good Git history"](https://masalmon.eu/2024/06/11/rewrite-git-history/);
+    - [The saperlipopette R package for practicing Git](https://docs.ropensci.org/saperlipopette/).
+
 - The default branch name should not be `master`, as this can be offensive to some people. Refer to the [statement of the Git project and the Software Freedom Conservancy](https://sfconservancy.org/news/2020/jun/23/gitbranchname/) for more context. It is general practice to name a default branch `main`, although other names may also be used. See the tidyverse blog post ["Renaming the default branch"](https://www.tidyverse.org/blog/2021/10/renaming-default-branch/) to learn about usethis functionality to help with renaming default branches.
 
 - Make sure to list "scrap" such as `.DS_Store` files in .gitignore. 

--- a/softwarereview_author.Rmd
+++ b/softwarereview_author.Rmd
@@ -51,7 +51,7 @@ This concise guide presents the software peer review process for you as a packag
 
 #### The importance of Git logs
 
-- The Git log is an important source of insight into design history, and a minimal requirement for all submissions remains an ability to grasp design history through a sufficiently extensive Git log.
+- The Git log can be an important source of insight into design history. Refer to our [version control](#version-control) guidance, which contains resources about creating informative Git logs.
 - While we place no current minimal limits on Git log size, we do note that [JOSS now requires at least six months of public commit history](https://joss.readthedocs.io/en/latest/submitting.html#:~:text=six%20months), and will defer to such requirements when considered necessary.
 
 ## Preparing for Submission {#preparing-for-submission}

--- a/softwarereview_author.Rmd
+++ b/softwarereview_author.Rmd
@@ -51,7 +51,7 @@ This concise guide presents the software peer review process for you as a packag
 
 #### The importance of Git logs
 
-- The Git log can be an important source of insight into design history. Refer to our [version control](#version-control) guidance, which contains resources about creating informative Git logs.
+- The Git log is an important source of insight into design history. Refer to our [version control](#version-control) guidance, which contains resources about creating informative Git logs.
 - While we place no current minimal limits on Git log size, we do note that [JOSS now requires at least six months of public commit history](https://joss.readthedocs.io/en/latest/submitting.html#:~:text=six%20months), and will defer to such requirements when considered necessary.
 
 ## Preparing for Submission {#preparing-for-submission}


### PR DESCRIPTION
The AI policies mention the Git log. As you know, I requested we add more resources about Git. I decided to be helpful and add them.

Then, seeing the phrase "a minimal requirement for all submissions remains an ability to grasp design history through a sufficiently extensive Git log" + a recent review experience made me wonder whether we actually had any requirements around Git commits... Well we don't. :sweat_smile: 

Since the Git log is so important to PR #1006, I am making this small PR against it. 